### PR TITLE
Add Cost of Intelligence chart mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,10 @@
 // ─── State ───────────────────────────────────────────────────
 let currentBenchmark = null; // Set to first benchmark key on init
-let currentMode = "frontier"; // "frontier" | "race"
+let currentMode = "frontier"; // "frontier" | "race" | "cost"
 let selectedLab = null;   // null = "All Labs", or a lab key like "openai"
+let currentCostBenchmark = null; // null = all, or "gpqa" / "mmlu-pro"
 let chart = null;
+let chartMode = null; // tracks which mode the chart was built for
 let isolatedIndex = null;
 
 // Category colors for tab dots
@@ -23,6 +25,12 @@ const BENCHMARK_COLORS = {
   "hle":        "#8b5cf6",
   "gpqa":       "#06b6d4",
   "aime":       "#ef4444",
+};
+
+// Colors for cost benchmarks
+const COST_BENCHMARK_COLORS = {
+  gpqa:       "#06b6d4",
+  "mmlu-pro": "#a855f7",
 };
 
 // ─── Initialize ──────────────────────────────────────────────
@@ -73,6 +81,8 @@ function renderFilterPills() {
 
   if (currentMode === "race") {
     renderBenchmarkPills(container);
+  } else if (currentMode === "cost") {
+    renderCostPills(container);
   } else {
     renderLabPills(container);
   }
@@ -145,6 +155,46 @@ function renderLabPills(container) {
   }
 }
 
+function renderCostPills(container) {
+  // "All Benchmarks" pill
+  const allBtn = document.createElement("button");
+  allBtn.className = `filter-pill${currentCostBenchmark === null ? " active" : ""}`;
+  allBtn.dataset.key = "all";
+  allBtn.textContent = "All Benchmarks";
+  allBtn.addEventListener("click", () => {
+    currentCostBenchmark = null;
+    container.querySelectorAll(".filter-pill").forEach(t => t.classList.remove("active"));
+    allBtn.classList.add("active");
+    isolatedIndex = null;
+    updateChart();
+  });
+  container.appendChild(allBtn);
+
+  // One pill per cost benchmark
+  for (const [key, meta] of Object.entries(COST_BENCHMARK_META)) {
+    const btn = document.createElement("button");
+    btn.className = `filter-pill${key === currentCostBenchmark ? " active" : ""}`;
+    btn.dataset.key = key;
+
+    const dot = document.createElement("span");
+    dot.className = "pill-dot";
+    dot.style.backgroundColor = meta.color;
+
+    btn.appendChild(dot);
+    btn.appendChild(document.createTextNode(`${meta.name} (${meta.thresholdLabel})`));
+
+    btn.addEventListener("click", () => {
+      currentCostBenchmark = key;
+      container.querySelectorAll(".filter-pill").forEach(t => t.classList.remove("active"));
+      btn.classList.add("active");
+      isolatedIndex = null;
+      updateChart();
+    });
+
+    container.appendChild(btn);
+  }
+}
+
 // ─── Mode toggle ─────────────────────────────────────────────
 function renderModeToggle() {
   document.querySelectorAll(".mode-btn").forEach(btn => {
@@ -158,6 +208,7 @@ function renderModeToggle() {
       btn.setAttribute("aria-selected", "true");
       isolatedIndex = null;
       selectedLab = null;
+      currentCostBenchmark = null;
       renderFilterPills();
       updateChart();
       renderInfoArea();
@@ -166,7 +217,37 @@ function renderModeToggle() {
 }
 
 // ─── Chart ───────────────────────────────────────────────────
+function buildCostDatasets() {
+  const keys = currentCostBenchmark ? [currentCostBenchmark] : Object.keys(COST_BENCHMARK_META);
+
+  return keys.map(key => {
+    const data = COST_DATA[key];
+    if (!data) return null;
+
+    const color = COST_BENCHMARK_COLORS[key];
+    return {
+      label: `${data.name} (${data.thresholdLabel})`,
+      data: data.entries.map(e => e ? e.price : null),
+      _models: data.entries.map(e => e ? e.model : null),
+      _labs: data.entries.map(e => e ? e.lab : null),
+      _scores: data.entries.map(e => e ? e.score : null),
+      borderColor: color,
+      backgroundColor: color + "33",
+      borderWidth: 2.5,
+      pointRadius: 4,
+      pointHoverRadius: 6,
+      pointBackgroundColor: color,
+      tension: 0.3,
+      spanGaps: true,
+    };
+  }).filter(Boolean);
+}
+
 function buildDatasets() {
+  if (currentMode === "cost") {
+    return buildCostDatasets();
+  }
+
   if (currentMode === "race") {
     const bench = BENCHMARKS[currentBenchmark];
     if (!bench) return [];
@@ -234,6 +315,61 @@ function buildDatasets() {
 
 function renderChart() {
   const ctx = document.getElementById("benchmarkChart").getContext("2d");
+  const isCost = currentMode === "cost";
+  chartMode = currentMode;
+
+  const yScale = isCost
+    ? {
+        type: "logarithmic",
+        grid: { color: "rgba(45, 49, 64, 0.5)" },
+        ticks: {
+          color: "#5f6368",
+          font: { size: 11 },
+          callback: val => {
+            if (val >= 1) return "$" + val.toFixed(0);
+            if (val >= 0.1) return "$" + val.toFixed(1);
+            return "$" + val.toFixed(2);
+          },
+        },
+      }
+    : {
+        min: 0,
+        max: 100,
+        grid: { color: "rgba(45, 49, 64, 0.5)" },
+        ticks: {
+          color: "#5f6368",
+          font: { size: 11 },
+          callback: val => val + "%",
+        },
+      };
+
+  const tooltipLabel = isCost
+    ? function(context) {
+        const val = context.parsed.y;
+        if (val === null) return null;
+        const model = context.dataset._models?.[context.dataIndex];
+        const lab = context.dataset._labs?.[context.dataIndex];
+        const score = context.dataset._scores?.[context.dataIndex];
+        let line = `${context.dataset.label}: $${val < 1 ? val.toFixed(3) : val.toFixed(2)}/M tokens`;
+        if (model) line += `\n  Model: ${model}`;
+        if (lab) line += ` (${lab})`;
+        if (score != null) line += `\n  Score: ${score}%`;
+        return line.split("\n");
+      }
+    : function(context) {
+        const val = context.parsed.y;
+        if (val === null) return null;
+        const model = context.dataset._models?.[context.dataIndex];
+        const labKey = context.dataset._labs?.[context.dataIndex];
+        const labName = labKey ? (LABS[labKey]?.name || labKey) : null;
+        let line = `${context.dataset.label}: ${val.toFixed(1)}%`;
+        if (model && labName) {
+          line += ` (${model}, ${labName})`;
+        } else if (model) {
+          line += ` (${model})`;
+        }
+        return line;
+      };
 
   chart = new Chart(ctx, {
     type: "line",
@@ -268,22 +404,7 @@ function renderChart() {
           borderWidth: 1,
           padding: 12,
           cornerRadius: 8,
-          callbacks: {
-            label: function(context) {
-              const val = context.parsed.y;
-              if (val === null) return null;
-              const model = context.dataset._models?.[context.dataIndex];
-              const labKey = context.dataset._labs?.[context.dataIndex];
-              const labName = labKey ? (LABS[labKey]?.name || labKey) : null;
-              let line = `${context.dataset.label}: ${val.toFixed(1)}%`;
-              if (model && labName) {
-                line += ` (${model}, ${labName})`;
-              } else if (model) {
-                line += ` (${model})`;
-              }
-              return line;
-            },
-          },
+          callbacks: { label: tooltipLabel },
         },
       },
       scales: {
@@ -291,16 +412,7 @@ function renderChart() {
           grid: { color: "rgba(45, 49, 64, 0.5)" },
           ticks: { color: "#5f6368", font: { size: 11 } },
         },
-        y: {
-          min: 0,
-          max: 100,
-          grid: { color: "rgba(45, 49, 64, 0.5)" },
-          ticks: {
-            color: "#5f6368",
-            font: { size: 11 },
-            callback: val => val + "%",
-          },
-        },
+        y: yScale,
       },
     },
   });
@@ -324,6 +436,16 @@ function handleLegendClick(_e, legendItem, legend) {
 
 function updateChart() {
   isolatedIndex = null;
+
+  // If switching between cost and non-cost, destroy and recreate (scale type changes)
+  const needsCost = currentMode === "cost";
+  const hadCost = chartMode === "cost";
+  if (needsCost !== hadCost) {
+    chart.destroy();
+    renderChart();
+    return;
+  }
+
   chart.data.datasets = buildDatasets();
   chart.data.datasets.forEach((_, i) => chart.setDatasetVisibility(i, true));
   chart.update();
@@ -332,8 +454,57 @@ function updateChart() {
 // ─── Info area ───────────────────────────────────────────────
 // Always renders the same expandable benchmark list in both modes.
 // In Lab Race, the currently selected benchmark is auto-expanded.
+function renderCostInfoArea(card) {
+  let html = '<div class="cost-headlines">';
+
+  for (const [key, meta] of Object.entries(COST_BENCHMARK_META)) {
+    const data = COST_DATA[key];
+    if (!data) continue;
+
+    // Find first and last non-null entries
+    const startIdx = TIME_LABELS.indexOf(meta.startQuarter);
+    let firstEntry = null, lastEntry = null;
+    let firstQ = null, lastQ = null;
+
+    for (let i = startIdx; i < data.entries.length; i++) {
+      if (data.entries[i]) {
+        if (!firstEntry) { firstEntry = data.entries[i]; firstQ = TIME_LABELS[i]; }
+        lastEntry = data.entries[i]; lastQ = TIME_LABELS[i];
+      }
+    }
+
+    if (firstEntry && lastEntry && firstEntry.price > 0 && lastEntry.price > 0) {
+      const decline = Math.round(firstEntry.price / lastEntry.price);
+      const fmtPrice = p => p >= 1 ? `$${p.toFixed(2)}` : `$${p.toFixed(3)}`;
+      html += `
+        <div class="cost-headline-item">
+          <span class="pill-dot" style="background-color: ${meta.color}"></span>
+          <span class="cost-headline-label">${meta.name} (${meta.thresholdLabel}):</span>
+          <span class="cost-decline">${decline}x cheaper</span>
+          <span class="cost-range">since ${firstQ} (${fmtPrice(firstEntry.price)} \u2192 ${fmtPrice(lastEntry.price)})</span>
+        </div>
+      `;
+    }
+  }
+
+  html += '</div>';
+  html += `
+    <div class="cost-explanation">
+      <p>Shows the cheapest model (any lab) scoring above a fixed threshold on each benchmark, measured in $/M tokens (blended 3:1 input:output). Thresholds are set at what the best model scored when each benchmark launched. Uses cumulative minimum \u2014 once a cheaper model exists, the price floor never rises.</p>
+    </div>
+  `;
+
+  card.innerHTML = html;
+}
+
 function renderInfoArea() {
   const card = document.getElementById("infoCard");
+
+  if (currentMode === "cost") {
+    renderCostInfoArea(card);
+    return;
+  }
+
   const autoExpand = (currentMode === "race") ? currentBenchmark : null;
 
   let html = '<div class="benchmark-list">';

--- a/data-loader.js
+++ b/data-loader.js
@@ -63,11 +63,28 @@ const BENCHMARK_META = {
   },
 };
 
+// Cost of Intelligence metadata
+const COST_BENCHMARK_META = {
+  gpqa: {
+    name: "GPQA Diamond", threshold: 36, thresholdLabel: "36%",
+    description: "Best-in-the-world science reasoning, Nov 2023",
+    context: "When GPQA Diamond launched, GPT-4 scored 35.7%",
+    color: "#06b6d4", startQuarter: "Q4 2023",
+  },
+  "mmlu-pro": {
+    name: "MMLU-Pro", threshold: 73, thresholdLabel: "73%",
+    description: "Best-in-the-world academic knowledge, Jun 2024",
+    context: "When MMLU-Pro launched, GPT-4o scored 72.6%",
+    color: "#a855f7", startQuarter: "Q2 2024",
+  },
+};
+
 // ─── Data loading ───────────────────────────────────────────────
 
 let BENCHMARKS = {};
+let COST_DATA = {};
 
-async function loadData() {
+async function loadBenchmarkScores() {
   const url = `${SUPABASE_URL}/rest/v1/benchmark_scores?select=benchmark,lab,quarter,score,model&order=benchmark,lab,quarter`;
 
   const response = await fetch(url, {
@@ -117,4 +134,47 @@ async function loadData() {
 
     BENCHMARKS[benchKey] = { ...meta, scores };
   }
+}
+
+async function loadCostData() {
+  const url = `${SUPABASE_URL}/rest/v1/cost_intelligence?select=benchmark,quarter,price,model,lab,score,threshold&order=benchmark,quarter`;
+
+  const response = await fetch(url, {
+    headers: {
+      "apikey": SUPABASE_ANON_KEY,
+      "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
+    },
+  });
+
+  if (!response.ok) {
+    console.warn("Cost data fetch failed:", response.status);
+    return;
+  }
+
+  const rows = await response.json();
+
+  const quarterIndex = {};
+  TIME_LABELS.forEach((q, i) => quarterIndex[q] = i);
+
+  COST_DATA = {};
+  for (const [benchKey, meta] of Object.entries(COST_BENCHMARK_META)) {
+    COST_DATA[benchKey] = {
+      ...meta,
+      entries: new Array(TIME_LABELS.length).fill(null),
+    };
+  }
+
+  for (const row of rows) {
+    if (!COST_DATA[row.benchmark]) continue;
+    const qi = quarterIndex[row.quarter];
+    if (qi === undefined) continue;
+
+    COST_DATA[row.benchmark].entries[qi] = row.price !== null
+      ? { price: parseFloat(row.price), model: row.model, lab: row.lab, score: parseFloat(row.score) }
+      : null;
+  }
+}
+
+async function loadData() {
+  await Promise.all([loadBenchmarkScores(), loadCostData()]);
 }

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       <div class="mode-toggle" role="tablist">
         <button class="mode-btn active" data-mode="frontier" role="tab" aria-selected="true">Frontier Progress</button>
         <button class="mode-btn" data-mode="race" role="tab" aria-selected="false">Lab Race</button>
+        <button class="mode-btn" data-mode="cost" role="tab" aria-selected="false">Cost of Intelligence</button>
       </div>
     </div>
 

--- a/scripts/update-data.js
+++ b/scripts/update-data.js
@@ -88,6 +88,12 @@ const ARC_LAB_PATTERNS = [
   [/^glm/i,          "chinese"],
 ];
 
+// Cost of Intelligence: benchmarks with price thresholds
+const COST_BENCHMARKS = {
+  gpqa:       { evalField: "gpqa",     threshold: 36, startQuarter: "Q4 2023" },
+  "mmlu-pro": { evalField: "mmlu_pro", threshold: 73, startQuarter: "Q2 2024" },
+};
+
 // Epoch: CSV files to process (AIME + ARC-AGI + SWE-bench for historical data)
 const EPOCH_BENCHMARK_FILES = {
   "otis_mock_aime_2024_2025.csv": { key: "aime",      scoreCol: "mean_score" },
@@ -162,6 +168,36 @@ function computeCumulativeBest(dataPoints, quarters) {
       const dp = dataPoints[dpIndex];
       if (best === null || dp.score > best.score) {
         best = { score: dp.score, model: dp.model, source: dp.source };
+      }
+      dpIndex++;
+    }
+
+    result[quarter] = best ? { ...best } : null;
+  }
+
+  return result;
+}
+
+/**
+ * Compute cumulative minimum price per quarter (for cost tracking).
+ * @param {Array<{date: Date, price: number, model: string, lab: string, score: number}>} dataPoints
+ * @param {string[]} quarters
+ * @returns {Object<string, {price: number, model: string, lab: string, score: number}|null>}
+ */
+function computeCumulativeMin(dataPoints, quarters) {
+  dataPoints.sort((a, b) => a.date - b.date);
+
+  const result = {};
+  let best = null;
+  let dpIndex = 0;
+
+  for (const quarter of quarters) {
+    const end = quarterEndDate(quarter);
+
+    while (dpIndex < dataPoints.length && dataPoints[dpIndex].date <= end) {
+      const dp = dataPoints[dpIndex];
+      if (best === null || dp.price < best.price) {
+        best = { price: dp.price, model: dp.model, lab: dp.lab, score: dp.score };
       }
       dpIndex++;
     }
@@ -484,6 +520,149 @@ async function fetchEpoch() {
   return results;
 }
 
+// ─── Source 5: Cost data (AA pricing + Epoch GPQA scores) ─────
+
+async function fetchCostData() {
+  console.log("   [Cost] Fetching AA pricing data...");
+  const response = await fetchJSON(
+    "https://artificialanalysis.ai/api/v2/data/llms/models",
+    { "x-api-key": AA_API_KEY }
+  );
+
+  const models = response.data || response;
+  if (!Array.isArray(models)) {
+    console.warn("   [Cost] WARN: Unexpected AA response structure");
+    return [];
+  }
+
+  const results = [];
+
+  // ── Part 1: AA models with both score and price (all benchmarks) ──
+  let aaCount = 0;
+  // Also build a price lookup for cross-referencing with Epoch
+  // Key: release_date string (YYYY-MM-DD) + "|" + lowercase lab name
+  const aaPriceLookup = new Map();
+
+  for (const model of models) {
+    const releaseDate = model.release_date ? new Date(model.release_date) : null;
+    if (!releaseDate || isNaN(releaseDate.getTime())) continue;
+
+    const pricing = model.pricing || {};
+    const price = pricing.price_1m_blended_3_to_1;
+    if (price == null || price <= 0) continue;
+
+    const modelName = model.name || model.slug || "Unknown";
+    const lab = model.model_creator?.name || "Unknown";
+
+    // Store in price lookup for Epoch cross-reference
+    const dateStr = model.release_date;
+    const labLower = lab.toLowerCase();
+    const lookupKey = `${dateStr}|${labLower}`;
+    // Keep cheapest price per date+lab (some labs have multiple models same day)
+    if (!aaPriceLookup.has(lookupKey) || price < aaPriceLookup.get(lookupKey).price) {
+      aaPriceLookup.set(lookupKey, { price, name: modelName, lab });
+    }
+    // Also store by model name for direct matching
+    aaPriceLookup.set(`name|${modelName.toLowerCase()}`, { price, name: modelName, lab, date: releaseDate });
+
+    const evals = model.evaluations || {};
+    for (const [benchKey, config] of Object.entries(COST_BENCHMARKS)) {
+      const rawScore = evals[config.evalField];
+      if (rawScore == null) continue;
+      const score = rawScore * 100;
+      if (score < config.threshold) continue;
+
+      results.push({
+        benchmark: benchKey,
+        date: releaseDate,
+        price,
+        score: Math.round(score * 10) / 10,
+        model: modelName,
+        lab,
+      });
+      aaCount++;
+    }
+  }
+
+  console.log(`   [Cost] ${aaCount} data points from AA (score+price)`);
+
+  // ── Part 2: Epoch GPQA scores cross-referenced with AA prices ──
+  // Epoch has GPQA scores for older models (GPT-4 Turbo etc.) that AA lacks
+  console.log("   [Cost] Fetching Epoch GPQA scores for cross-reference...");
+  let epochCount = 0;
+  try {
+    const { zipPath, tmpDir } = await downloadFile("https://epoch.ai/data/benchmark_data.zip");
+    const zip = new AdmZip(zipPath);
+    const gpqaEntry = zip.getEntries().find(e => path.basename(e.entryName) === "gpqa_diamond.csv");
+
+    if (gpqaEntry) {
+      const records = parse(gpqaEntry.getData().toString("utf-8"), {
+        columns: true, skip_empty_lines: true, trim: true, relax_column_count: true,
+      });
+
+      const gpqaConfig = COST_BENCHMARKS["gpqa"];
+
+      for (const row of records) {
+        const rawScore = parseFloat(row["mean_score"]);
+        if (isNaN(rawScore)) continue;
+        const score = rawScore <= 1.0 ? rawScore * 100 : rawScore;
+        if (score < gpqaConfig.threshold) continue;
+
+        const dateStr = row["Release date"];
+        if (!dateStr) continue;
+        const releaseDate = new Date(dateStr);
+        if (isNaN(releaseDate.getTime())) continue;
+
+        const epochOrg = row["Organization"] || "";
+
+        // Try to find AA price: match by date + lab
+        const orgLower = epochOrg.toLowerCase().split(",")[0].trim();
+        const lookupKey = `${dateStr}|${orgLower}`;
+        let match = aaPriceLookup.get(lookupKey);
+
+        // Fallback: try common org name variations
+        if (!match) {
+          const orgVariations = {
+            "meta ai": "meta",
+            "google deepmind": "google",
+            "mistral ai": "mistral",
+          };
+          const altOrg = orgVariations[orgLower];
+          if (altOrg) match = aaPriceLookup.get(`${dateStr}|${altOrg}`);
+        }
+
+        if (!match) continue;
+
+        // Check we don't already have an AA data point for this exact model+date
+        const isDuplicate = results.some(r =>
+          r.benchmark === "gpqa" &&
+          r.date.getTime() === releaseDate.getTime() &&
+          r.lab.toLowerCase() === match.lab.toLowerCase()
+        );
+        if (isDuplicate) continue;
+
+        results.push({
+          benchmark: "gpqa",
+          date: releaseDate,
+          price: match.price,
+          score: Math.round(score * 10) / 10,
+          model: match.name,
+          lab: match.lab,
+        });
+        epochCount++;
+      }
+    }
+
+    try { fs.rmSync(tmpDir, { recursive: true }); } catch (_) {}
+  } catch (err) {
+    console.warn("   [Cost] WARN: Epoch cross-reference failed:", err.message);
+  }
+
+  console.log(`   [Cost] ${epochCount} additional GPQA data points from Epoch cross-reference`);
+  console.log(`   [Cost] ${results.length} total cost data points`);
+  return results;
+}
+
 function findCol(headers, preferred, candidates) {
   if (preferred && headers.includes(preferred)) return preferred;
   for (const c of candidates) {
@@ -512,13 +691,31 @@ async function main() {
     process.exit(1);
   }
 
+  // Check cost_intelligence table exists
+  const { error: costSchemaErr } = await supabase
+    .from("cost_intelligence")
+    .select("benchmark")
+    .limit(1);
+
+  if (costSchemaErr) {
+    console.error("\n   cost_intelligence table not found! Run in the Supabase SQL editor:");
+    console.error("     CREATE TABLE cost_intelligence (");
+    console.error("       id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,");
+    console.error("       benchmark TEXT NOT NULL, quarter TEXT NOT NULL,");
+    console.error("       price NUMERIC, model TEXT, lab TEXT, score NUMERIC,");
+    console.error("       threshold NUMERIC NOT NULL, UNIQUE (benchmark, quarter)");
+    console.error("     );");
+    process.exit(1);
+  }
+
   // Fetch from all 4 sources in parallel
   console.log("\n1. Fetching from all sources...");
-  const [aaData, sweData, arcData, epochData] = await Promise.all([
+  const [aaData, sweData, arcData, epochData, costData] = await Promise.all([
     fetchArtificialAnalysis().catch(err => { console.error("   [AA] FAILED:", err.message); return []; }),
     fetchSWEBench().catch(err => { console.error("   [SWE] FAILED:", err.message); return []; }),
     fetchARCPrize().catch(err => { console.error("   [ARC] FAILED:", err.message); return []; }),
     fetchEpoch().catch(err => { console.error("   [Epoch] FAILED:", err.message); return []; }),
+    fetchCostData().catch(err => { console.error("   [Cost] FAILED:", err.message); return []; }),
   ]);
 
   // Merge all data points by benchmark
@@ -610,6 +807,67 @@ async function main() {
   }
 
   console.log(`   Upserted ${allRows.length} rows successfully.`);
+
+  // ─── Cost of Intelligence processing ────────────────────────
+  console.log("\n4. Processing cost data...");
+
+  // Group cost data by benchmark
+  const costByBenchmark = {};
+  for (const dp of costData) {
+    if (!costByBenchmark[dp.benchmark]) costByBenchmark[dp.benchmark] = [];
+    costByBenchmark[dp.benchmark].push(dp);
+  }
+
+  const costRows = [];
+  for (const [benchKey, config] of Object.entries(COST_BENCHMARKS)) {
+    const points = costByBenchmark[benchKey] || [];
+    const cumulMin = computeCumulativeMin(points, QUARTERS);
+
+    const startIdx = QUARTERS.indexOf(config.startQuarter);
+
+    for (const [quarter, best] of Object.entries(cumulMin)) {
+      const qi = QUARTERS.indexOf(quarter);
+      const isBeforeStart = qi < startIdx;
+
+      costRows.push({
+        benchmark: benchKey,
+        quarter,
+        price: isBeforeStart ? null : (best ? Math.round(best.price * 1000) / 1000 : null),
+        model: isBeforeStart ? null : (best?.model || null),
+        lab: isBeforeStart ? null : (best?.lab || null),
+        score: isBeforeStart ? null : (best?.score || null),
+        threshold: config.threshold,
+      });
+    }
+
+    const validPoints = Object.entries(cumulMin)
+      .filter(([q]) => QUARTERS.indexOf(q) >= startIdx)
+      .filter(([, v]) => v !== null);
+    if (validPoints.length > 0) {
+      const first = validPoints[0][1];
+      const last = validPoints[validPoints.length - 1][1];
+      const decline = first.price / last.price;
+      console.log(`   ${benchKey}: ${validPoints.length} quarters, $${first.price.toFixed(2)} → $${last.price.toFixed(2)} (${decline.toFixed(0)}x decline)`);
+    } else {
+      console.log(`   ${benchKey}: no data points above threshold`);
+    }
+  }
+
+  // Upsert cost data
+  console.log(`\n5. Upserting ${costRows.length} cost rows to Supabase...`);
+  for (let i = 0; i < costRows.length; i += BATCH_SIZE) {
+    const batch = costRows.slice(i, i + BATCH_SIZE);
+    const { error } = await supabase
+      .from("cost_intelligence")
+      .upsert(batch, { onConflict: "benchmark,quarter" });
+
+    if (error) {
+      console.error(`   Cost upsert FAILED:`, error.message);
+      process.exit(1);
+    }
+  }
+
+  console.log(`   Upserted ${costRows.length} cost rows successfully.`);
   console.log("\nDone!");
 }
 

--- a/styles.css
+++ b/styles.css
@@ -409,6 +409,49 @@ main {
   border-color: var(--text-muted);
 }
 
+/* Cost of Intelligence info area */
+.cost-headlines {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cost-headline-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.cost-headline-label {
+  font-weight: 500;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+}
+
+.cost-decline {
+  color: #10b981;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.cost-range {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.cost-explanation {
+  border-top: 1px solid var(--border);
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+}
+
+.cost-explanation p {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
 /* Footer */
 footer {
   text-align: center;


### PR DESCRIPTION
Third chart mode showing how the price of achieving a fixed benchmark threshold has plummeted over time. Tracks cheapest model (any lab) scoring above threshold on GPQA Diamond (36%) and MMLU-Pro (73%), measured in $/M tokens (blended 3:1 input:output).

- New Supabase table: cost_intelligence
- Backend: fetchCostData() with Epoch GPQA cross-reference for historical coverage, computeCumulativeMin(), cost upsert pipeline
- Frontend: log-scale Y-axis, currency tooltips, filter pills, headline stats showing Xx price decline per benchmark