### PR TITLE
Add Vercel Web Analytics for cookieless visitor tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,5 +68,6 @@
 
   <script src="data-loader.js"></script>
   <script src="app.js"></script>
+  <script defer src="/_vercel/insights/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Adds cookieless Vercel Web Analytics script to index.html for visitor tracking before the LinkedIn launch
  - GDPR compliant — no cookies, no  personal data, no consent banner   needed

  After merge: Go to Vercel dashboard → Analytics tab → Enable Web Analytics