### PR TITLE
Add analytics queue initialization script for plain HTML support

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
 
   <script src="data-loader.js"></script>
   <script src="app.js"></script>
+  <script>window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };</script>
   <script defer src="/_vercel/insights/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The /_vercel/insights/script.js endpoint requires the window.va queue to be initialized first on non-framework sites.