### PR TITLE
Structured LLM analysis with pre-computed stats

### DIFF
--- a/api/analyze.js
+++ b/api/analyze.js
@@ -1,20 +1,40 @@
 const Anthropic = require("@anthropic-ai/sdk").default;
 
-const SYSTEM_PROMPT = `You are a sharp AI industry analyst writing for executive presentations.
-Given benchmark performance data for frontier AI models, produce a concise
-analysis suitable for copy-pasting into presentation slides.
+const SYSTEM_PROMPT = `You are a sharp AI industry analyst. You produce structured reports on AI benchmark performance using pre-computed statistics and raw data.
+
+You MUST follow this exact template structure. Do not add, remove, or reorder sections.
+
+---
+
+**Key Developments [Q_ 20__ to Q_ 20__]**
+
+The frontier scores on active benchmarks grew by an average of X%. The biggest increase came from [benchmark name] which measures [one-line plain-English description] — increasing by X%.
+
+**[Lab name]** is currently leading the pack, with an average position of X across our X active benchmarks, leading in X. This compares to an average position of X at the beginning of the period and a leading position in X. Their rise appears to be driven by [1-2 sentences citing specific model names and score jumps from the raw data].
+
+The biggest loser in this period is **[Lab name]** who fell from an average position of X at the start of the period, to X at the end. This fall appears to be driven by [1-2 sentences citing specific models and where competitors overtook them].
+
+During this period, it became **Xx cheaper** to achieve [threshold]% on [benchmark 1] and **Xx cheaper** to achieve [threshold]% on [benchmark 2], which were the frontier scores when those benchmarks were released. This represents [one sentence explaining in plain language what those scores/benchmarks mean, using the description and context fields].
+
+**Headlines you can copy with pride:**
+- [First headline — intelligence increase and cost decrease, with numbers]
+- [Second headline — main lab race changes, with names]
+- [Third headline — wild card, something surprising or provocative]
+
+---
 
 Rules:
-- Lead with the single most important headline finding
-- Use 3-5 bullet points maximum
-- Each bullet: one key insight with specific numbers
-- Name the models and labs — be specific
-- Note surprising gaps, accelerations, or reversals
-- End with a one-sentence forward-looking statement
-- No hedging, no filler, no "it's worth noting" — be direct
-- Format: markdown with **bold** for emphasis`;
+- Tone: straightforward, no-bullshit. Write like a sharp analyst who respects the reader's time. No corporate filler, no hedging ("it's worth noting", "interestingly"), no throat-clearing. Say what happened and why it matters.
+- Use the pre-computed numbers directly from the stats JSON. Do not recalculate.
+- The "driven by" sentences MUST reference specific model names and score jumps from the raw benchmark data.
+- Headlines: punchy, specific, LinkedIn-ready. Include numbers and lab names.
+- If rankings barely changed or there is no clear biggest loser, say so honestly. Do not fabricate drama.
+- If a cost benchmark has cheaperMultiple of null, omit it from the cost section. If all are null, omit the entire cost paragraph.
+- No extra sections beyond the template. Follow the structure exactly.
+- Formatting: use **bold** on the title, lab names on first mention in leader/loser sections, cost multiples (e.g. **12x cheaper**), and the "Headlines" subheading. Use - prefix for headline bullets. Separate each section with a blank line.
+- Do not use ## headings within the report. Only **bold text** for section markers.`;
 
-const MAX_BODY_SIZE = 50000; // 50KB — plenty for benchmark data
+const MAX_BODY_SIZE = 100000; // 100KB — expanded for stats payload
 
 let client = null;
 function getClient() {
@@ -36,17 +56,24 @@ module.exports = async function handler(req, res) {
     return res.status(413).json({ error: "Request too large" });
   }
 
-  const { startQuarter, endQuarter, benchmarkData } = req.body;
-  if (!startQuarter || !endQuarter || !benchmarkData) {
-    return res.status(400).json({ error: "Missing required fields: startQuarter, endQuarter, benchmarkData" });
+  const { startQuarter, endQuarter, benchmarkData, stats, costData } = req.body;
+  if (!startQuarter || !endQuarter || !benchmarkData || !stats || !costData) {
+    return res.status(400).json({ error: "Missing required fields: startQuarter, endQuarter, benchmarkData, stats, costData" });
   }
 
-  const userPrompt = `Analyze the following AI benchmark data from ${startQuarter} to ${endQuarter}:\n\n${benchmarkData}`;
+  const userPrompt = `=== PRE-COMPUTED STATISTICS ===
+${JSON.stringify(stats, null, 2)}
+
+=== COST OF INTELLIGENCE ===
+${JSON.stringify(costData, null, 2)}
+
+=== RAW BENCHMARK SCORES (${startQuarter} to ${endQuarter}) ===
+${benchmarkData}`;
 
   try {
     const message = await getClient().messages.create({
       model: "claude-sonnet-4-6",
-      max_tokens: 1024,
+      max_tokens: 2048,
       system: SYSTEM_PROMPT,
       messages: [{ role: "user", content: userPrompt }],
     });

--- a/app.js
+++ b/app.js
@@ -706,11 +706,184 @@ document.addEventListener("DOMContentLoaded", () => {
       return lines.join("\n");
     }
 
+    // --- Pre-compute helpers for structured analysis ---
+
+    function getLatestScore(scoresArray, maxIdx) {
+      for (let i = maxIdx; i >= 0; i--) {
+        if (scoresArray[i]) return { score: scoresArray[i].score, model: scoresArray[i].model };
+      }
+      return null;
+    }
+
+    function computeRankings(startIdx, endIdx) {
+      const labKeys = Object.keys(LABS);
+      const benchKeys = Object.keys(BENCHMARKS);
+
+      function rankAtIndex(idx) {
+        const perLab = {};
+        for (const labKey of labKeys) perLab[labKey] = { ranks: [], firsts: 0, detail: {} };
+
+        for (const benchKey of benchKeys) {
+          const bench = BENCHMARKS[benchKey];
+          // Collect scores for each lab at this index
+          const entries = [];
+          for (const labKey of labKeys) {
+            const entry = getLatestScore(bench.scores[labKey], idx);
+            if (entry) entries.push({ labKey, score: entry.score, model: entry.model });
+          }
+          if (entries.length === 0) continue;
+
+          // Sort descending by score
+          entries.sort((a, b) => b.score - a.score);
+
+          // Dense ranking (1,1,2 for ties)
+          let rank = 1;
+          for (let i = 0; i < entries.length; i++) {
+            if (i > 0 && entries[i].score < entries[i - 1].score) rank++;
+            const lab = entries[i].labKey;
+            perLab[lab].ranks.push(rank);
+            perLab[lab].detail[benchKey] = { rank, score: entries[i].score, model: entries[i].model };
+            if (rank === 1) perLab[lab].firsts++;
+          }
+        }
+
+        // Compute averages
+        const result = {};
+        for (const labKey of labKeys) {
+          const d = perLab[labKey];
+          if (d.ranks.length === 0) continue;
+          result[labKey] = {
+            avgRank: Math.round((d.ranks.reduce((a, b) => a + b, 0) / d.ranks.length) * 10) / 10,
+            firsts: d.firsts,
+            benchmarksRanked: d.ranks.length,
+            detail: d.detail,
+          };
+        }
+        return result;
+      }
+
+      const startRanks = rankAtIndex(startIdx);
+      const endRanks = rankAtIndex(endIdx);
+
+      // Identify leader (lowest avg rank at end)
+      let leader = null, lowestAvg = Infinity;
+      for (const [labKey, data] of Object.entries(endRanks)) {
+        if (data.avgRank < lowestAvg) { lowestAvg = data.avgRank; leader = labKey; }
+      }
+
+      // Identify biggest loser (largest increase in avg rank)
+      let biggestLoser = null, biggestDrop = -Infinity;
+      for (const [labKey, endData] of Object.entries(endRanks)) {
+        const startData = startRanks[labKey];
+        if (!startData) continue;
+        const drop = endData.avgRank - startData.avgRank;
+        if (drop > biggestDrop) { biggestDrop = drop; biggestLoser = labKey; }
+      }
+      // If no one got worse, biggestLoser stays null
+      if (biggestDrop <= 0) biggestLoser = null;
+
+      return {
+        leader: leader ? {
+          lab: LABS[leader].name,
+          labKey: leader,
+          startAvgRank: startRanks[leader] ? startRanks[leader].avgRank : null,
+          startFirsts: startRanks[leader] ? startRanks[leader].firsts : 0,
+          endAvgRank: endRanks[leader].avgRank,
+          endFirsts: endRanks[leader].firsts,
+          detail: endRanks[leader].detail,
+        } : null,
+        biggestLoser: biggestLoser ? {
+          lab: LABS[biggestLoser].name,
+          labKey: biggestLoser,
+          startAvgRank: startRanks[biggestLoser].avgRank,
+          startFirsts: startRanks[biggestLoser].firsts,
+          endAvgRank: endRanks[biggestLoser].avgRank,
+          endFirsts: endRanks[biggestLoser].firsts,
+          detail: endRanks[biggestLoser].detail,
+        } : null,
+      };
+    }
+
+    function computeFrontierGrowth(startIdx, endIdx) {
+      const labKeys = Object.keys(LABS);
+      const results = [];
+      for (const [benchKey, bench] of Object.entries(BENCHMARKS)) {
+        let startMax = null, endMax = null;
+        for (const labKey of labKeys) {
+          const s = getLatestScore(bench.scores[labKey], startIdx);
+          const e = getLatestScore(bench.scores[labKey], endIdx);
+          if (s && (startMax === null || s.score > startMax)) startMax = s.score;
+          if (e && (endMax === null || e.score > endMax)) endMax = e.score;
+        }
+        if (startMax === null || endMax === null || startMax === 0) continue;
+        const growth = Math.round(((endMax - startMax) / startMax) * 1000) / 10;
+        results.push({
+          benchmark: bench.name,
+          description: bench.description.split(" — ")[0],
+          startScore: startMax,
+          endScore: endMax,
+          growthPct: growth,
+        });
+      }
+      results.sort((a, b) => b.growthPct - a.growthPct);
+      const avg = results.length > 0 ? Math.round((results.reduce((s, r) => s + r.growthPct, 0) / results.length) * 10) / 10 : 0;
+      return { benchmarks: results, avgGrowthPct: avg, biggestMover: results[0] || null };
+    }
+
+    function computeCostDecline(startIdx, endIdx) {
+      const results = [];
+      for (const [benchKey, meta] of Object.entries(COST_BENCHMARK_META)) {
+        const data = COST_DATA[benchKey];
+        if (!data) continue;
+
+        // Find entry at/before start and end
+        let startEntry = null, endEntry = null;
+        for (let i = startIdx; i >= 0; i--) {
+          if (data.entries[i]) { startEntry = data.entries[i]; break; }
+        }
+        for (let i = endIdx; i >= 0; i--) {
+          if (data.entries[i]) { endEntry = data.entries[i]; break; }
+        }
+
+        if (!startEntry || !endEntry || startEntry.price <= 0 || endEntry.price <= 0) {
+          results.push({ benchmark: meta.name, threshold: meta.thresholdLabel, cheaperMultiple: null, description: meta.description, context: meta.context });
+          continue;
+        }
+
+        const multiple = Math.round((startEntry.price / endEntry.price) * 10) / 10;
+        results.push({
+          benchmark: meta.name,
+          threshold: meta.thresholdLabel,
+          startPrice: startEntry.price,
+          endPrice: endEntry.price,
+          startModel: startEntry.model,
+          endModel: endEntry.model,
+          cheaperMultiple: multiple,
+          description: meta.description,
+          context: meta.context,
+        });
+      }
+      return results;
+    }
+
+    // --- End pre-compute helpers ---
+
     async function generateAnalysis() {
       const { startIdx, endIdx } = getQuarterRange();
       const startQ = TIME_LABELS[startIdx];
       const endQ = TIME_LABELS[endIdx];
       const benchmarkData = getDataForRange(startIdx, endIdx);
+
+      // Pre-compute statistics for structured analysis
+      const frontierGrowth = computeFrontierGrowth(startIdx, endIdx);
+      const rankings = computeRankings(startIdx, endIdx);
+      const stats = {
+        frontierGrowth,
+        leader: rankings.leader,
+        biggestLoser: rankings.biggestLoser,
+        activeBenchmarkCount: frontierGrowth.benchmarks.length,
+      };
+      const costData = computeCostDecline(startIdx, endIdx);
 
       generateBtn.disabled = true;
       loadingEl.hidden = false;
@@ -720,7 +893,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const resp = await fetch("/api/analyze", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ startQuarter: startQ, endQuarter: endQ, benchmarkData }),
+          body: JSON.stringify({ startQuarter: startQ, endQuarter: endQ, benchmarkData, stats, costData }),
         });
 
         if (!resp.ok) {


### PR DESCRIPTION
## Summary
- Pre-compute frontier growth, lab rankings (dense ranking), and cost decline client-side, feeding structured stats JSON to the LLM alongside raw data so it narrates rather than calculates
- Rewrite system/user prompts with an exact report template (key developments, leader, loser, cost, headlines) and strict tone/formatting rules
- Bump max_tokens from 1024 to 2048

## Test plan
- [ ] Run preview server, select various time ranges, generate analysis
- [ ] Check that pre-computed numbers in output match what's visible in charts
- [ ] Verify output follows template structure consistently across runs
- [ ] Test edge cases: 1-quarter range, full range, range where a lab has no data
- [ ] Deploy to Vercel preview and test live

🤖 Generated with [Claude Code](https://claude.com/claude-code)