### PR TITLE
Add error and loading states

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,8 +73,8 @@ function showLoading(show) {
   if (show && !existing) {
     const el = document.createElement("div");
     el.id = "loadingIndicator";
-    el.style.cssText = "display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-secondary);font-size:0.95rem;";
-    el.textContent = "Loading benchmark data\u2026";
+    el.className = "chart-status";
+    el.innerHTML = '<div class="spinner"></div>Loading benchmark data\u2026';
     container.appendChild(el);
   } else if (!show && existing) {
     existing.remove();
@@ -82,8 +82,8 @@ function showLoading(show) {
 }
 
 function showError(message) {
-  document.querySelector(".chart-container").innerHTML =
-    `<div style="display:flex;align-items:center;justify-content:center;height:100%;color:#ef4444;font-size:0.95rem;text-align:center;padding:2rem;">${message}</div>`;
+  const container = document.querySelector(".chart-container");
+  container.innerHTML = `<div class="chart-status error">${escapeHtml(message)}<button class="retry-btn" onclick="location.reload()">Try again</button></div>`;
 }
 
 // ─── Filter pills (benchmark tabs OR lab tabs) ──────────────
@@ -433,10 +433,43 @@ const inactivityMarkerPlugin = {
 
 Chart.register(inactivityMarkerPlugin);
 
+function showChartMessage(message) {
+  let overlay = document.getElementById("chartMessage");
+  if (!overlay) {
+    overlay = document.createElement("div");
+    overlay.id = "chartMessage";
+    overlay.className = "chart-status chart-overlay";
+    document.querySelector(".chart-canvas-wrapper").appendChild(overlay);
+  }
+  overlay.textContent = message;
+}
+
+function clearChartMessage() {
+  const el = document.getElementById("chartMessage");
+  if (el) el.remove();
+}
+
 function renderChart() {
+  clearChartMessage();
   const ctx = document.getElementById("benchmarkChart").getContext("2d");
   const isCost = currentMode === "cost";
   chartMode = currentMode;
+
+  // Cost data failed to load — show message instead of chart
+  if (isCost && costLoadFailed) {
+    chart = new Chart(ctx, {
+      type: "line",
+      data: { labels: [], datasets: [] },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+        devicePixelRatio: CHART_DPR,
+      },
+    });
+    showChartMessage("Cost data is temporarily unavailable. Please try again later.");
+    return;
+  }
 
   const yScale = isCost
     ? {
@@ -537,6 +570,12 @@ function renderChart() {
       devicePixelRatio: CHART_DPR,
     },
   });
+
+  // Empty state: check if all data points are null
+  const hasData = chart.data.datasets.some(ds => ds.data.some(v => v !== null));
+  if (!hasData) {
+    showChartMessage("No data available for this view.");
+  }
 }
 
 // ─── Custom HTML Legend ──────────────────────────────────────
@@ -830,6 +869,7 @@ function updateChart() {
   isolatedIndex = null;
   highlightedInactiveIndex = null;
   hideInactiveTooltip();
+  clearChartMessage();
 
   // If switching between cost and non-cost, destroy and recreate (scale type changes)
   const needsCost = currentMode === "cost";
@@ -845,6 +885,12 @@ function updateChart() {
   chart.data.datasets.forEach((_, i) => chart.setDatasetVisibility(i, true));
   chart.update();
   renderCustomLegend();
+
+  // Check empty state after update
+  const hasData = chart.data.datasets.some(ds => ds.data.some(v => v !== null));
+  if (!hasData) {
+    showChartMessage("No data available for this view.");
+  }
 }
 
 // ─── Info area ───────────────────────────────────────────────

--- a/data-loader.js
+++ b/data-loader.js
@@ -142,16 +142,29 @@ const COST_BENCHMARK_META = {
 
 let BENCHMARKS = {};
 let COST_DATA = {};
+let costLoadFailed = false;
 
 async function loadBenchmarkScores() {
   const url = `${SUPABASE_URL}/rest/v1/benchmark_scores?select=benchmark,lab,quarter,score,model&order=benchmark,lab,quarter`;
 
-  const response = await fetch(url, {
-    headers: {
-      "apikey": SUPABASE_ANON_KEY,
-      "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
-    },
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15000);
+
+  let response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        "apikey": SUPABASE_ANON_KEY,
+        "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
+      },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timeoutId);
+    if (err.name === "AbortError") throw new Error("Request timed out");
+    throw err;
+  }
+  clearTimeout(timeoutId);
 
   if (!response.ok) {
     throw new Error(`Supabase fetch failed: ${response.status} ${response.statusText}`);
@@ -198,15 +211,29 @@ async function loadBenchmarkScores() {
 async function loadCostData() {
   const url = `${SUPABASE_URL}/rest/v1/cost_intelligence?select=benchmark,quarter,price,model,lab,score,threshold&order=benchmark,quarter`;
 
-  const response = await fetch(url, {
-    headers: {
-      "apikey": SUPABASE_ANON_KEY,
-      "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
-    },
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15000);
+
+  let response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        "apikey": SUPABASE_ANON_KEY,
+        "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
+      },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timeoutId);
+    console.warn("Cost data fetch failed:", err.name === "AbortError" ? "Request timed out" : err.message);
+    costLoadFailed = true;
+    return;
+  }
+  clearTimeout(timeoutId);
 
   if (!response.ok) {
     console.warn("Cost data fetch failed:", response.status);
+    costLoadFailed = true;
     return;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -467,6 +467,47 @@ main {
   cursor: not-allowed;
 }
 
+/* Chart loading / error / empty states */
+.chart-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  text-align: center;
+  padding: 2rem;
+}
+
+.chart-status.error {
+  color: #ef4444;
+}
+
+.chart-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  background: var(--bg-secondary);
+}
+
+.retry-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  padding: 0.5rem 1.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.retry-btn:hover {
+  opacity: 0.85;
+}
+
 .analysis-loading {
   align-items: center;
   gap: 0.6rem;


### PR DESCRIPTION
## Summary
- **Spinner on load**: Replaces plain "Loading benchmark data..." text with an animated spinner + text using the existing `.spinner` CSS class
- **Retry on error**: `showError()` now shows a "Try again" button that reloads the page; error message is HTML-escaped
- **Fetch timeouts**: Both Supabase fetches use `AbortController` with a 15-second timeout; timeout errors surface as "Request timed out"
- **Cost failure surfaced**: `loadCostData()` sets a `costLoadFailed` flag instead of silently returning; the Cost tab shows "Cost data is temporarily unavailable" when the flag is set
- **Empty chart state**: After rendering, if all data points are null, an overlay shows "No data available for this view"

## Test plan
- [ ] Confirm spinner appears briefly during initial page load
- [ ] Temporarily break Supabase URL → verify red error message + "Try again" button appears and works
- [ ] Temporarily set timeout to 1ms → verify "Request timed out" error
- [ ] Temporarily break cost endpoint only → verify Cost tab shows unavailable message while other tabs work fine
- [ ] Confirm normal operation after restoring all URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)