### PR TITLE
Rearchitect analysis: structured stat cards + LLM commentary

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,6 +53,7 @@ let chart = null;
 let chartMode = null; // tracks which mode the chart was built for
 let isolatedIndex = null;
 let highlightedInactiveIndex = null; // currently highlighted inactive dataset
+let cachedAnalysis = null; // parsed JSON from Supabase
 
 // Clipboard SVG icon for copy buttons
 const COPY_ICON_SVG = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5.5" y="5.5" width="8" height="8" rx="1.5"/><path d="M10.5 5.5V3.5a1.5 1.5 0 00-1.5-1.5H3.5A1.5 1.5 0 002 3.5V9a1.5 1.5 0 001.5 1.5h2"/></svg>';
@@ -333,6 +334,7 @@ function renderModeToggle() {
       renderFilterPills();
       updateChart(); // also calls renderCustomLegend() + updateCitationLine()
       renderInfoArea();
+      renderAnalysisCard(currentMode);
     });
   });
 }
@@ -1046,101 +1048,77 @@ function updateChart() {
 }
 
 // ─── Info area ───────────────────────────────────────────────
-function renderCostInfoArea(card) {
-  let html = '<div class="cost-headlines">';
-
-  for (const [key, meta] of Object.entries(COST_BENCHMARK_META)) {
-    const data = COST_DATA[key];
-    if (!data) continue;
-
-    const startIdx = TIME_LABELS.indexOf(meta.startQuarter);
-    let firstEntry = null, lastEntry = null;
-    let firstQ = null, lastQ = null;
-
-    for (let i = startIdx; i < data.entries.length; i++) {
-      if (data.entries[i]) {
-        if (!firstEntry) { firstEntry = data.entries[i]; firstQ = TIME_LABELS[i]; }
-        lastEntry = data.entries[i]; lastQ = TIME_LABELS[i];
-      }
-    }
-
-    if (firstEntry && lastEntry && firstEntry.price > 0 && lastEntry.price > 0) {
-      const decline = Math.round(firstEntry.price / lastEntry.price);
-      const fmtPrice = p => p >= 1 ? `$${p.toFixed(2)}` : `$${p.toFixed(3)}`;
-      html += `
-        <div class="cost-headline-item">
-          <span class="pill-dot" style="background-color: ${meta.color}"></span>
-          <span class="cost-headline-label">${meta.name} (${meta.thresholdLabel}):</span>
-          <span class="cost-decline">${decline}x cheaper</span>
-          <span class="cost-range">since ${firstQ} (${fmtPrice(firstEntry.price)} \u2192 ${fmtPrice(lastEntry.price)})</span>
-        </div>
-      `;
-    }
-  }
-
-  html += '</div>';
-  html += `
-    <div class="cost-explanation">
-      <p>Shows the cheapest model (any lab) scoring above a fixed threshold on each benchmark, measured in $/M tokens (blended 3:1 input:output). Thresholds are set at what the best model scored when each benchmark launched. Uses cumulative minimum: once a cheaper model exists, the price floor never rises.</p>
-    </div>
-  `;
-
-  card.innerHTML = html;
-}
-
 function renderInfoArea() {
   const card = document.getElementById("infoCard");
 
-  if (currentMode === "cost") {
-    renderCostInfoArea(card);
-    return;
-  }
-
-  const autoExpand = (currentMode === "race") ? currentBenchmark : null;
   const filterEnd = getFilterEndDate();
+
+  // Methodology intro varies by mode
+  const methodologyText = currentMode === "cost"
+    ? "Shows the cheapest model (any lab) scoring above a fixed threshold on each benchmark, measured in $/M tokens (blended 3:1 input:output). Thresholds are set at what the best model scored when each benchmark launched. Uses cumulative minimum: once a cheaper model exists, the price floor never rises."
+    : 'Scores use independently verified sources wherever available (Artificial Analysis, Epoch AI, ARC Prize, SWE-bench, Scale AI SEAL), shown as solid dots. Where no independent evaluation exists yet, self-reported model card scores from official lab announcements are used, shown as <strong>hollow dots</strong>.';
 
   let html = `
     <div class="methodology-intro" id="methodologySection">
-      <p>Scores use independently verified sources wherever available (Artificial Analysis, Epoch AI, ARC Prize, SWE-bench, Scale AI SEAL), shown as solid dots. Where no independent evaluation exists yet, self-reported model card scores from official lab announcements are used, shown as <strong>hollow dots</strong>.</p>
+      <p>${methodologyText}</p>
     </div>
   `;
   html += '<div class="benchmark-list">';
 
-  for (const [key, bench] of Object.entries(BENCHMARKS)) {
-    const color = BENCHMARK_COLORS[key] || INACTIVE_COLOR;
-    const isOpen = key === autoExpand;
-    const isInactive = !isBenchmarkActive(key, filterEnd);
-    const meta = BENCHMARK_META[key];
-
-    // Status badge
-    let statusBadge = "";
-    if (isInactive && meta.status === "deprecated") {
-      statusBadge = `<span class="status-badge deprecated">Deprecated ${meta.activeUntil}</span>`;
-    } else if (isInactive && meta.status === "saturated") {
-      statusBadge = `<span class="status-badge saturated">Saturated ${meta.activeUntil}</span>`;
-    }
-
-    // Description with inactive reason
-    let description = bench.description;
-    if (isInactive && meta.inactiveReason) {
-      description += ` <em style="color:var(--text-muted);">${meta.inactiveReason}.</em>`;
-    }
-
-    html += `
-      <div class="benchmark-item" data-bench="${key}">
-        <button class="benchmark-item-header" aria-expanded="${isOpen}">
-          <span class="pill-dot" style="background-color: ${isInactive ? INACTIVE_COLOR : color}"></span>
-          <span class="benchmark-item-name">${bench.name}</span>
-          <span class="category-badge">${bench.category}</span>
-          ${statusBadge}
-          <span class="expand-icon">${isOpen ? "\u2212" : "+"}</span>
-        </button>
-        <div class="benchmark-item-detail"${isOpen ? "" : " hidden"}>
-          <p>${description}</p>
-          <a href="${bench.link}" target="_blank" rel="noopener">Learn more &rarr;</a>
+  if (currentMode === "cost") {
+    for (const [key, meta] of Object.entries(COST_BENCHMARK_META)) {
+      const color = COST_BENCHMARK_COLORS[key] || "#6c9eff";
+      html += `
+        <div class="benchmark-item">
+          <button class="benchmark-item-header" aria-expanded="false">
+            <span class="pill-dot" style="background-color: ${color}"></span>
+            <span class="benchmark-item-name">${meta.name}</span>
+            <span class="expand-icon">+</span>
+          </button>
+          <div class="benchmark-item-detail" hidden>
+            <p>${meta.description}</p>
+            ${meta.link ? `<a href="${meta.link}" target="_blank" rel="noopener">Learn more &rarr;</a>` : ""}
+          </div>
         </div>
-      </div>
-    `;
+      `;
+    }
+  } else {
+    for (const [key, bench] of Object.entries(BENCHMARKS)) {
+      const color = BENCHMARK_COLORS[key] || INACTIVE_COLOR;
+      const isOpen = false;
+      const isInactive = !isBenchmarkActive(key, filterEnd);
+      const meta = BENCHMARK_META[key];
+
+      // Status badge
+      let statusBadge = "";
+      if (isInactive && meta.status === "deprecated") {
+        statusBadge = `<span class="status-badge deprecated">Deprecated ${meta.activeUntil}</span>`;
+      } else if (isInactive && meta.status === "saturated") {
+        statusBadge = `<span class="status-badge saturated">Saturated ${meta.activeUntil}</span>`;
+      }
+
+      // Description with inactive reason
+      let description = bench.description;
+      if (isInactive && meta.inactiveReason) {
+        description += ` <em style="color:var(--text-muted);">${meta.inactiveReason}.</em>`;
+      }
+
+      html += `
+        <div class="benchmark-item" data-bench="${key}">
+          <button class="benchmark-item-header" aria-expanded="${isOpen}">
+            <span class="pill-dot" style="background-color: ${isInactive ? INACTIVE_COLOR : color}"></span>
+            <span class="benchmark-item-name">${bench.name}</span>
+            <span class="category-badge">${bench.category}</span>
+            ${statusBadge}
+            <span class="expand-icon">${isOpen ? "\u2212" : "+"}</span>
+          </button>
+          <div class="benchmark-item-detail"${isOpen ? "" : " hidden"}>
+            <p>${description}</p>
+            <a href="${bench.link}" target="_blank" rel="noopener">Learn more &rarr;</a>
+          </div>
+        </div>
+      `;
+    }
   }
 
   html += '</div>';
@@ -1172,6 +1150,9 @@ function populateDateRangeYears() {
   const select = document.getElementById("dateRange");
   const years = [...new Set(TIME_LABELS.map(q => q.substring(3)))];
   for (const year of years) {
+    // Skip single-quarter years (no meaningful change to show)
+    const quartersInYear = TIME_LABELS.filter(q => q.endsWith(year));
+    if (quartersInYear.length <= 1) continue;
     const opt = document.createElement("option");
     opt.value = year;
     opt.textContent = year;
@@ -1222,19 +1203,6 @@ function applyDateRange() {
 }
 
 // ─── Analysis fetch & render ─────────────────────────────────
-function renderMarkdown(md) {
-  return escapeHtml(md)
-    .replace(/^## (.+)$/gm, "<h2>$1</h2>")
-    .replace(/^### (.+)$/gm, "<h3>$1</h3>")
-    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-    .replace(/\*(.+?)\*/g, "<em>$1</em>")
-    .replace(/^- (.+)$/gm, "<li>$1</li>")
-    .replace(/(<li>.*<\/li>\n?)+/g, (m) => `<ul>${m}</ul>`)
-    .replace(/\n{2,}/g, "</p><p>")
-    .replace(/^(?!<[hup]|<li|<ul)(.+)$/gm, "<p>$1</p>")
-    .replace(/<p><\/p>/g, "");
-}
-
 async function fetchAnalysis(preset) {
   const section = document.getElementById("analysisSection");
   section.innerHTML = '<div class="analysis-loading-inline"><div class="spinner"></div></div>';
@@ -1252,74 +1220,116 @@ async function fetchAnalysis(preset) {
     const rows = await resp.json();
 
     if (rows.length === 0 || !rows[0].analysis) {
+      cachedAnalysis = null;
       section.innerHTML = '<div class="analysis-empty">No analysis available for this time range.</div>';
       return;
     }
 
-    renderAnalysisSections(rows[0].analysis, section);
+    try {
+      cachedAnalysis = JSON.parse(rows[0].analysis);
+    } catch (e) {
+      cachedAnalysis = null;
+      section.innerHTML = '<div class="analysis-empty">Failed to parse analysis data.</div>';
+      return;
+    }
+
+    renderAnalysisCard(currentMode);
   } catch (err) {
     console.error("Failed to fetch analysis:", err);
+    cachedAnalysis = null;
     section.innerHTML = '<div class="analysis-empty">Failed to load analysis.</div>';
   }
 }
 
-function renderAnalysisSections(markdown, container) {
-  // Split on ### headers
-  const sections = [];
-  let currentSection = null;
-
-  for (const line of markdown.split("\n")) {
-    if (line.startsWith("### ")) {
-      if (currentSection) sections.push(currentSection);
-      currentSection = { title: line.substring(4).trim(), lines: [] };
-    } else if (line.startsWith("## ")) {
-      // Top-level heading — render as intro
-      if (currentSection) sections.push(currentSection);
-      currentSection = { title: null, rawTitle: line.substring(3).trim(), lines: [] };
-    } else {
-      if (currentSection) currentSection.lines.push(line);
-      else {
-        currentSection = { title: null, lines: [line] };
-      }
-    }
-  }
-  if (currentSection) sections.push(currentSection);
-
-  let html = '';
-
-  for (const sec of sections) {
-    if (sec.rawTitle) {
-      // Top-level ## heading with disclaimer
-      html += `<div class="analysis-heading"><h2>${escapeHtml(sec.rawTitle)}</h2><span class="analysis-disclaimer">Analysis generated by Opus 4.6 using the benchmark data shown. May contain errors!</span></div>`;
-      continue;
-    }
-
-    const body = sec.lines.join("\n").trim();
-    if (!body && !sec.title) continue;
-
-    if (sec.title === "Headlines") {
-      // Render each bullet as a separate item with its own copy button
-      const bullets = body.split("\n").filter(l => l.startsWith("- ")).map(l => l.substring(2).trim());
-      html += '<div class="analysis-card headlines-card">';
-      html += '<div class="section-header"><h3>Headlines</h3></div>';
-      html += '<ul class="headline-list">';
-      for (const bullet of bullets) {
-        const rendered = renderMarkdown("- " + bullet).replace(/<\/?ul>/g, "").replace(/<\/?li>/g, "");
-        html += `<li class="headline-item"><span class="headline-text">${rendered.trim()}</span><button class="copy-icon-btn" title="Copy headline" data-copy-text="${escapeHtml(bullet)}">${COPY_ICON_SVG}</button></li>`;
-      }
-      html += '</ul></div>';
-    } else if (sec.title) {
-      // Body section with heading + copy icon
-      const rendered = renderMarkdown(body);
-      const plainText = body.replace(/\*\*(.+?)\*\*/g, "$1").replace(/\*(.+?)\*/g, "$1");
-      html += `<div class="analysis-card"><div class="section-header"><h3>${escapeHtml(sec.title)}</h3><button class="copy-icon-btn" title="Copy section" data-copy-text="${escapeHtml(sec.title + "\n\n" + plainText)}">${COPY_ICON_SVG}</button></div><div class="analysis-text">${rendered}</div></div>`;
-    }
+function renderAnalysisCard(mode) {
+  const section = document.getElementById("analysisSection");
+  if (!cachedAnalysis) {
+    section.innerHTML = '<div class="analysis-empty">No analysis available for this time range.</div>';
+    return;
   }
 
-  container.innerHTML = html;
+  const data = cachedAnalysis[mode];
+  if (!data) {
+    section.innerHTML = '<div class="analysis-empty">No analysis available for this mode.</div>';
+    return;
+  }
 
-  // Wire copy buttons
-  container.querySelectorAll(".copy-icon-btn").forEach(btn => {
+  const plainParts = [];
+  let html = '<div class="analysis-card">';
+
+  // Copy button (top-right)
+  // (copyText populated below, wired after innerHTML set)
+
+  // Callout stats (bulleted list)
+  html += '<ul class="callout-stats">';
+
+  if (mode === "frontier") {
+    const c = data.callouts || {};
+    if (c.medianIncrease) {
+      html += `<li class="callout-line"><span><span class="callout-obj">\u2191</span> <span class="callout-num">${escapeHtml(c.medianIncrease.value)}</span> <span class="callout-obj">median increase</span> ${escapeHtml(c.medianIncrease.detail)}</span></li>`;
+      plainParts.push(`↑ ${c.medianIncrease.value} median increase ${c.medianIncrease.detail}`);
+    }
+    if (c.biggestMover) {
+      const pp = c.biggestMover.ppChange;
+      html += `<li class="callout-line"><span><span class="callout-obj">Biggest gain: ${escapeHtml(c.biggestMover.name)}</span>, <span class="callout-num">${pp >= 0 ? "+" : ""}${pp}</span> percentage points${c.biggestMover.periodLabel ? " " + escapeHtml(c.biggestMover.periodLabel) : ""}</span></li>`;
+      plainParts.push(`Biggest gain: ${c.biggestMover.name}, ${pp >= 0 ? "+" : ""}${pp} pp`);
+    }
+    if (c.benchmarksSaturated) {
+      html += `<li class="callout-line"><span><span class="callout-num">${c.benchmarksSaturated.count}</span> <span class="callout-obj">major benchmarks defeated</span>: ${escapeHtml(c.benchmarksSaturated.names.join(", "))}</span></li>`;
+      plainParts.push(`${c.benchmarksSaturated.count} defeated: ${c.benchmarksSaturated.names.join(", ")}`);
+    }
+  } else if (mode === "race") {
+    const c = data.callouts || {};
+    if (c.leader) {
+      const l = c.leader;
+      let changeText = "";
+      if (l.direction && l.direction !== "unchanged" && l.startAvgRank !== null) {
+        const dirWord = l.direction === "down" ? "improving from" : "worsening from";
+        changeText = `, ${dirWord} <span class="callout-num">${l.startAvgRank}</span> ${l.monthsBack} months ago`;
+      }
+      html += `<li class="callout-line"><span><span class="callout-obj">Overall Leader: ${escapeHtml(l.name)}</span> Avg. rank <span class="callout-num">${l.avgRank}</span> across ${l.benchmarkCount} active benchmarks${changeText}. <span class="callout-num">${l.firsts}</span> first-place finishes</span></li>`;
+      plainParts.push(`Overall Leader: ${l.name}. Avg rank ${l.avgRank}. ${l.firsts} firsts`);
+    }
+    if (c.biggestMover) {
+      const m = c.biggestMover;
+      const dirWord = m.direction === "improved" ? "improving from" : "worsening from";
+      const startRank = Math.round((m.avgRank - m.change) * 10) / 10;
+      html += `<li class="callout-line"><span><span class="callout-obj">Biggest mover: ${escapeHtml(m.name)}</span> Avg. rank <span class="callout-num">${m.avgRank}</span> across ${m.benchmarkCount || (c.leader ? c.leader.benchmarkCount : 6)} active benchmarks, ${dirWord} <span class="callout-num">${startRank}</span> ${m.monthsBack} months ago. <span class="callout-num">${m.firsts}</span> first-place finishes</span></li>`;
+      plainParts.push(`Biggest mover: ${m.name}. Avg rank ${m.avgRank}, ${dirWord} ${startRank}`);
+    }
+  } else if (mode === "cost") {
+    const fmtPrice = p => p >= 1 ? `$${p.toFixed(2)}` : `$${p.toFixed(3)}`;
+    for (const item of (data.callouts || [])) {
+      html += `<li class="callout-line"><span><span class="callout-obj">${escapeHtml(item.benchmark)} (${escapeHtml(item.threshold)})</span>: <span class="callout-num">${escapeHtml(item.decline)}</span> cheaper now versus ${escapeHtml(item.startQ)} (${fmtPrice(item.startPrice)} \u2192 ${fmtPrice(item.endPrice)})</span></li>`;
+      plainParts.push(`${item.benchmark}: ${item.decline} cheaper now vs ${item.startQ} (${fmtPrice(item.startPrice)} → ${fmtPrice(item.endPrice)})`);
+    }
+  }
+  html += '</ul>';
+
+  // Headline + commentary
+  if (data.headline) {
+    html += `<p class="analysis-headline">${escapeHtml(data.headline)}</p>`;
+    plainParts.push(data.headline);
+  }
+  if (data.commentary) {
+    html += `<p class="analysis-commentary">${escapeHtml(data.commentary)}</p>`;
+    plainParts.push(data.commentary);
+  }
+
+  // Disclaimer
+  html += '<div class="analysis-footer">';
+  html += '<span class="analysis-disclaimer">Stats computed. Not all labs submit for all benchmarks. Analysis generated by Opus 4.6, may contain errors.</span>';
+  html += '</div>';
+
+  // Copy button (top-right, positioned absolute)
+  const copyText = plainParts.join("\n");
+  html += `<button class="copy-icon-btn" title="Copy analysis" data-copy-text="${escapeHtml(copyText)}">${COPY_ICON_SVG}</button>`;
+
+  html += '</div>';
+  section.innerHTML = html;
+
+  // Wire copy button
+  section.querySelectorAll(".copy-icon-btn").forEach(btn => {
     btn.addEventListener("click", () => {
       const text = btn.getAttribute("data-copy-text");
       navigator.clipboard.writeText(text).then(() => {

--- a/data-loader.js
+++ b/data-loader.js
@@ -142,14 +142,14 @@ function isBenchmarkActive(benchKey, filterEndQuarter) {
 const COST_BENCHMARK_META = {
   gpqa: {
     name: "GPQA Diamond", threshold: 36, thresholdLabel: "36%",
-    description: "Best-in-the-world science reasoning, Nov 2023",
-    context: "When GPQA Diamond launched, GPT-4 scored 35.7%",
+    description: "Graduate-level science questions in physics, chemistry, and biology. Domain experts achieve ~65%; non-experts perform at chance. The cost threshold (36%) is set at what GPT-4 scored when the benchmark launched in late 2023. Pricing data from Artificial Analysis.",
+    link: "https://arxiv.org/abs/2311.12022",
     color: "#06b6d4", startQuarter: "Q4 2023",
   },
   "mmlu-pro": {
     name: "MMLU-Pro", threshold: 73, thresholdLabel: "73%",
-    description: "Best-in-the-world academic knowledge, Jun 2024",
-    context: "When MMLU-Pro launched, GPT-4o scored 72.6%",
+    description: "A harder successor to MMLU with 10 answer choices (vs 4) across 14 academic subjects, designed to test genuine reasoning rather than recall. The cost threshold (73%) is set at what GPT-4o scored when the benchmark launched in mid-2024. Pricing data from Artificial Analysis.",
+    link: "https://arxiv.org/abs/2406.01574",
     color: "#a855f7", startQuarter: "Q2 2024",
   },
 };

--- a/lib/analysis-prompt.js
+++ b/lib/analysis-prompt.js
@@ -1,52 +1,47 @@
-const SYSTEM_PROMPT = `You are a sharp AI industry analyst writing a brief for professionals who track AI progress. You receive pre-computed statistics, cost data, and raw benchmark scores for a specific time period.
+const SYSTEM_PROMPT = `You are a sharp AI industry analyst. You receive pre-computed statistics and raw benchmark data for a specific time period. Your job is to write short, qualitative commentary that interprets the data. The numbers are already computed and will be displayed as stat cards; you provide the narrative.
 
-=== DATA LIMITATIONS ===
-- A dash (-) in the raw data means NO DATA, not a score of zero. Do not interpret missing data as poor performance.
-- The stats include labDataCoverage showing how many active benchmarks each lab has data for. If a lab has low coverage or flat scores across all benchmarks, note this explicitly — do not speculate about their performance.
-- "Chinese Leaders" is a composite of the best score from any Chinese lab (DeepSeek, Alibaba, etc.) — not a single lab.
-- Benchmarks tagged [SATURATED] or [DEPRECATED] in the raw data are inactive. Do NOT discuss them in AI Frontier or Lab Race sections.
-
-=== REPORT TEMPLATE ===
-Follow this template exactly. Fill in the [placeholders] using the stats JSON and raw data. Each section can be OMITTED per the conditions noted — if omitted, skip it entirely (no heading, no text).
-
-## Key Developments [startQuarter to endQuarter]
-
-### Headlines
-
-- [Intelligence gains + cost decline, with numbers]
-- [Lab race shift, with names]
-- The single strongest signal in the data — short, sharp, plain English. No consultancy gloss, no jargon, no sensationalism.
-
-### AI Frontier
-
-Frontier scores on leading, active benchmarks grew by an average of [avgGrowthPct]%. The biggest increase came in [biggest mover benchmark name] — [one-line plain-English description of what that benchmark measures]. It jumped [growthPct]% from [startScore] to [endScore], driven by [model name from raw data].
-
-[INCLUDE ONLY IF stats.defeatedThisPeriod is non-empty:]
-[Benchmark name(s)] was/were effectively defeated this period — [reason from defeatedThisPeriod data, e.g. "scores converged at 97%+ across all labs" or "replaced by harder successor"].
-
-### Lab Race
-
-**[Leader lab name]** currently leads the pack [max a few words to describe level of lead, e.g. "narrowly", "by a substantial margin"]. Their average rank across active benchmarks moved from [startAvgRank] to [endAvgRank], picking up [endFirsts] first-place finishes. This rise was driven by [1-2 specific model names + score jumps from raw data].
-
-**[Biggest loser lab name]** fell from average rank [startAvgRank] to [endAvgRank]. [1 sentence on why, citing specific models/scores.] [If the lab has low coverage in labDataCoverage, add: "Note: [lab] has data for only [X/Y] active benchmarks, so rankings may not reflect their full capability."]
-
-[OMIT this entire section if rankings barely changed.]
-
-### Cost of Intelligence
-
-[FOR EACH cost benchmark where cheaperMultiple represents a >= 10% decline:]
-It became [Xx cheaper / X% cheaper] to match [threshold description] on [benchmark name] — down from $[startPrice] to $[endPrice] per million tokens.
-
-[OMIT this entire section if no cost benchmark showed a meaningful decline (>= 10%).]
+=== OUTPUT FORMAT ===
+Return ONLY valid JSON, no markdown fences, no extra text:
+{
+  "frontier": {
+    "headline": "One punchy sentence summarizing frontier progress",
+    "commentary": "1-2 sentences with pace/freshness observations"
+  },
+  "race": {
+    "headline": "One punchy sentence on the lab race",
+    "commentary": "1-2 sentences explaining who moved and why"
+  },
+  "cost": {
+    "headline": "One punchy sentence on cost trends",
+    "commentary": "1-2 sentences on what the cost decline means"
+  }
+}
 
 === RULES ===
-- Tone: straightforward, no-bullshit. No corporate filler, no hedging ("it's worth noting", "interestingly"), no throat-clearing.
-- Use pre-computed numbers from the stats JSON. Do not recalculate.
-- When expressing any change: use "Xx" for multiples >= 2 (e.g. "4x growth"), use percentage for changes < 2x (e.g. "rose 60%"). Apply this consistently across all sections.
-- "Driven by" sentences MUST cite specific model names and score jumps from the raw data.
-- Headlines must include concrete numbers and lab names. Do NOT use **bold** formatting within headlines — plain text only.
-- Formatting: Use ## and ### headings exactly as shown. Use **bold** for lab names on first mention and cost figures (but NOT in headlines). Use - for headline bullets. Blank line between sections.
-- Follow the template structure exactly when the data fits. If the data for the selected period makes a section or sentence nonsensical (e.g. no loser because all labs improved, single-quarter range making "growth" meaningless), adapt the wording to fit the data. Always preserve the structure, style, and purpose of the report when deviating.
+1. HEADLINES: The user already sees the stat lines (median increase, biggest gain, leader, cost decline). Your headline must NOT just restate those numbers. Instead, add context, interpretation, or a connection the stats alone don't make. Include concrete numbers and lab names. Plain text only, no **bold**. Data-driven and punchy. Can be provocative if the data supports it. No AI hype. No-bullshit tone.
+   - Good: "Google DeepMind leads 4 of 6 benchmarks while OpenAI holds just 1"
+   - Good: "ARC-AGI-2 went from unsolvable to 85% in three quarters, faster than any benchmark in tracking history"
+   - Bad: "Frontier scores surged 122% across 6 active benchmarks" (just restating the stat)
+   - Bad: "The AI race heats up as labs push boundaries" (no substance)
+
+2. CALLOUT CONSISTENCY: The CALLOUT STATS section shows exactly what the user sees as stat lines. Your headlines and commentary must reference the same numbers shown in the callouts. Do not recompute or contradict them. Note that frontier callouts may use a trailing 12-month window (indicated by "last 12 months" in the detail text); if so, your frontier headline should also focus on that window.
+
+3. COMMENTARY: Add interpretation the stat cards alone don't convey. 1-2 sentences max per mode.
+   - For frontier: Look at the per-quarter breakdown. If progress was concentrated in specific quarters, or accelerated/decelerated notably, mention it. If data freshness shows a lab's scores are >1 quarter old, caveat your commentary.
+   - For race: Explain what drove the leader's position (which benchmarks). If the leader also has the biggest fall, explain the situation. Use "lost ground" or "fell behind" language, never "biggest loser".
+   - For cost: Ground the decline in what it means practically.
+
+4. TONE: Straightforward, no corporate filler. No hedging ("it's worth noting", "interestingly"). No throat-clearing.
+
+5. CHANGES: When expressing any change, use "Xx" for multiplier >= 2 (e.g. "3.5x growth"). Use percentage for changes < 2x (e.g. "rose 60%"). Scores are percentage points: "from 10 to 35 = 3.5x. From 40 to 60 = rose 50%."
+
+6. OMISSION: If a mode has no meaningful data (no benchmarks with data, no cost decline, all rankings unchanged), return empty strings for headline and commentary. Do not fabricate.
+
+7. DATA LIMITATIONS:
+   - A dash (-) in the raw data means NO DATA, not zero. Do not interpret missing data as poor performance.
+   - "Chinese Leaders" is a composite of the best score from any Chinese lab (DeepSeek, Alibaba, etc.), not a single lab.
+   - Benchmarks tagged [SATURATED] or [DEPRECATED] are inactive. Do NOT discuss them in frontier or race commentary.
+   - Check LAB DATA COVERAGE: if a lab has low coverage, note it.
 
 === LAB NAME REFERENCE ===
 openai = OpenAI, anthropic = Anthropic, google = Google DeepMind, xai = xAI, chinese = Chinese Leaders`;

--- a/scripts/generate-analyses.js
+++ b/scripts/generate-analyses.js
@@ -1,9 +1,29 @@
 // scripts/generate-analyses.js
 // Pre-generates AI analysis for all date range presets and stores them in Supabase.
-// Fetches data from Supabase, computes stats (same logic as app.js), calls Claude, upserts results.
+// Computes structured stats (callouts), calls Claude for qualitative commentary,
+// stores merged JSON in cached_analyses.
 //
 // Usage:
-//   SUPABASE_SERVICE_KEY=xxx ANTHROPIC_API_KEY=xxx node scripts/generate-analyses.js
+//   node scripts/generate-analyses.js            # all presets, reads .env
+//   node scripts/generate-analyses.js all-time    # single preset
+
+const fs = require("fs");
+const path = require("path");
+
+// Load .env file from project root
+const envPath = path.resolve(__dirname, "../.env");
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, "utf8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx > 0) {
+      const key = trimmed.substring(0, eqIdx);
+      const val = trimmed.substring(eqIdx + 1);
+      if (!process.env[key]) process.env[key] = val;
+    }
+  }
+}
 
 const Anthropic = require("@anthropic-ai/sdk").default;
 const { createClient } = require("@supabase/supabase-js");
@@ -94,7 +114,7 @@ const BENCHMARK_META = {
   },
   "frontiermath": {
     name: "FrontierMath", category: "Math", status: "active",
-    description: "Research-level mathematics problems (Tiers 1–3)",
+    description: "Research-level mathematics problems (Tiers 1-3)",
   },
   "math-l5": {
     name: "MATH Level 5", category: "Math", status: "saturated",
@@ -107,14 +127,12 @@ const BENCHMARK_META = {
 const COST_BENCHMARK_META = {
   gpqa: {
     name: "GPQA Diamond", threshold: 36, thresholdLabel: "36%",
-    description: "Best-in-the-world science reasoning, Nov 2023",
-    context: "When GPQA Diamond launched, GPT-4 scored 35.7%",
+    description: "Graduate-level science questions in physics, chemistry, and biology. Domain experts achieve ~65%; non-experts perform at chance. The cost threshold (36%) is set at what GPT-4 scored when the benchmark launched in late 2023.",
     startQuarter: "Q4 2023",
   },
   "mmlu-pro": {
     name: "MMLU-Pro", threshold: 73, thresholdLabel: "73%",
-    description: "Best-in-the-world academic knowledge, Jun 2024",
-    context: "When MMLU-Pro launched, GPT-4o scored 72.6%",
+    description: "A harder successor to MMLU with 10 answer choices (vs 4) across 14 academic subjects, designed to test genuine reasoning rather than recall. The cost threshold (73%) is set at what GPT-4o scored when the benchmark launched in mid-2024.",
     startQuarter: "Q2 2024",
   },
 };
@@ -143,7 +161,6 @@ let BENCHMARKS = {};
 let COST_DATA = {};
 
 async function loadData() {
-  // Load benchmark scores
   const { data: scoreRows, error: scoreErr } = await supabase
     .from("benchmark_scores")
     .select("benchmark,lab,quarter,score,model")
@@ -182,7 +199,6 @@ async function loadData() {
     BENCHMARKS[benchKey] = { ...meta, scores };
   }
 
-  // Load cost data
   const { data: costRows, error: costErr } = await supabase
     .from("cost_intelligence")
     .select("benchmark,quarter,price,model,lab,score,threshold")
@@ -210,7 +226,7 @@ async function loadData() {
   }
 }
 
-// ─── Stat functions (ported from app.js) ─────────────────────
+// ─── Stat functions ──────────────────────────────────────────
 
 function getLatestScore(scoresArray, maxIdx) {
   for (let i = maxIdx; i >= 0; i--) {
@@ -219,41 +235,91 @@ function getLatestScore(scoresArray, maxIdx) {
   return null;
 }
 
+function getEarliestScore(scoresArray, minIdx, maxIdx) {
+  for (let i = minIdx; i <= maxIdx; i++) {
+    if (scoresArray[i]) return { score: scoresArray[i].score, model: scoresArray[i].model };
+  }
+  return null;
+}
+
 function computeFrontierGrowth(startIdx, endIdx) {
+  const filterEnd = getFilterEndDate();
   const labKeys = Object.keys(LABS);
   const results = [];
   for (const [benchKey, bench] of Object.entries(BENCHMARKS)) {
+    if (!isBenchmarkActive(benchKey, filterEnd)) continue;
     let startMax = null, endMax = null;
     for (const labKey of labKeys) {
-      const s = getLatestScore(bench.scores[labKey], startIdx);
+      // Find earliest data point in range for start, latest for end
+      const s = getEarliestScore(bench.scores[labKey], startIdx, endIdx);
       const e = getLatestScore(bench.scores[labKey], endIdx);
       if (s && (startMax === null || s.score > startMax)) startMax = s.score;
       if (e && (endMax === null || e.score > endMax)) endMax = e.score;
     }
-    if (startMax === null || endMax === null || startMax === 0) continue;
-    const growth = Math.round(((endMax - startMax) / startMax) * 1000) / 10;
+    if (startMax === null || endMax === null) continue;
+    const ppChange = Math.round((endMax - startMax) * 10) / 10;
+    const relPct = startMax > 0 ? Math.round(((endMax - startMax) / startMax) * 1000) / 10 : null;
     results.push({
       benchmark: bench.name,
-      description: bench.description.split(" \u2014 ")[0],
+      benchKey,
       startScore: startMax,
       endScore: endMax,
-      growthPct: growth,
+      ppChange,
+      relPct,
     });
   }
-  results.sort((a, b) => b.growthPct - a.growthPct);
-  const avg = results.length > 0 ? Math.round((results.reduce((s, r) => s + r.growthPct, 0) / results.length) * 10) / 10 : 0;
-  return { benchmarks: results, avgGrowthPct: avg, biggestMover: results[0] || null };
+  results.sort((a, b) => b.ppChange - a.ppChange);
+
+  // Median relative increase (handles low-base outliers better than mean)
+  const validRel = results.filter(r => r.relPct !== null).map(r => r.relPct).sort((a, b) => a - b);
+  let medianRelPct = 0;
+  if (validRel.length > 0) {
+    const mid = Math.floor(validRel.length / 2);
+    medianRelPct = validRel.length % 2 === 0
+      ? Math.round(((validRel[mid - 1] + validRel[mid]) / 2) * 10) / 10
+      : validRel[mid];
+  }
+
+  return { benchmarks: results, medianRelPct, biggestMover: results[0] || null };
+}
+
+function computePerQuarterFrontier(startIdx, endIdx) {
+  const filterEnd = getFilterEndDate();
+  const labKeys = Object.keys(LABS);
+  const activeBenchKeys = Object.keys(BENCHMARKS).filter(k => isBenchmarkActive(k, filterEnd));
+  const quarters = {};
+
+  for (let qi = startIdx; qi <= endIdx; qi++) {
+    const qLabel = TIME_LABELS[qi];
+    const benchScores = {};
+    for (const benchKey of activeBenchKeys) {
+      const bench = BENCHMARKS[benchKey];
+      let bestScore = null;
+      for (const labKey of labKeys) {
+        const entry = bench.scores[labKey][qi];
+        if (entry && (bestScore === null || entry.score > bestScore)) {
+          bestScore = entry.score;
+        }
+      }
+      if (bestScore !== null) benchScores[bench.name] = bestScore;
+    }
+    if (Object.keys(benchScores).length > 0) {
+      quarters[qLabel] = benchScores;
+    }
+  }
+  return quarters;
 }
 
 function computeRankings(startIdx, endIdx) {
+  const filterEnd = getFilterEndDate();
   const labKeys = Object.keys(LABS);
-  const benchKeys = Object.keys(BENCHMARKS);
+  const activeBenchKeys = Object.keys(BENCHMARKS).filter(k => isBenchmarkActive(k, filterEnd));
 
   function rankAtIndex(idx) {
     const perLab = {};
     for (const labKey of labKeys) perLab[labKey] = { ranks: [], firsts: 0, detail: {} };
 
-    for (const benchKey of benchKeys) {
+    for (const benchKey of activeBenchKeys) {
       const bench = BENCHMARKS[benchKey];
       const entries = [];
       for (const labKey of labKeys) {
@@ -296,34 +362,38 @@ function computeRankings(startIdx, endIdx) {
     if (data.avgRank < lowestAvg) { lowestAvg = data.avgRank; leader = labKey; }
   }
 
-  let biggestLoser = null, biggestDrop = -Infinity;
+  // Biggest mover: largest absolute rank change, excluding the leader
+  let biggestMover = null, biggestAbsChange = 0;
   for (const [labKey, endData] of Object.entries(endRanks)) {
+    if (labKey === leader) continue;
     const startData = startRanks[labKey];
     if (!startData) continue;
-    const drop = endData.avgRank - startData.avgRank;
-    if (drop > biggestDrop) { biggestDrop = drop; biggestLoser = labKey; }
+    const change = endData.avgRank - startData.avgRank;
+    if (Math.abs(change) > biggestAbsChange) {
+      biggestAbsChange = Math.abs(change);
+      biggestMover = { labKey, change };
+    }
   }
-  if (biggestDrop <= 0) biggestLoser = null;
 
   return {
     leader: leader ? {
       lab: LABS[leader].name,
       labKey: leader,
       startAvgRank: startRanks[leader] ? startRanks[leader].avgRank : null,
-      startFirsts: startRanks[leader] ? startRanks[leader].firsts : 0,
       endAvgRank: endRanks[leader].avgRank,
       endFirsts: endRanks[leader].firsts,
+      benchmarksRanked: endRanks[leader].benchmarksRanked,
       detail: endRanks[leader].detail,
     } : null,
-    biggestLoser: biggestLoser ? {
-      lab: LABS[biggestLoser].name,
-      labKey: biggestLoser,
-      startAvgRank: startRanks[biggestLoser].avgRank,
-      startFirsts: startRanks[biggestLoser].firsts,
-      endAvgRank: endRanks[biggestLoser].avgRank,
-      endFirsts: endRanks[biggestLoser].firsts,
-      detail: endRanks[biggestLoser].detail,
+    biggestMover: biggestMover && biggestAbsChange > 0 ? {
+      lab: LABS[biggestMover.labKey].name,
+      labKey: biggestMover.labKey,
+      change: biggestMover.change,
+      startAvgRank: startRanks[biggestMover.labKey].avgRank,
+      endAvgRank: endRanks[biggestMover.labKey].avgRank,
+      endFirsts: endRanks[biggestMover.labKey].firsts,
     } : null,
+    allRanks: endRanks,
   };
 }
 
@@ -333,33 +403,58 @@ function computeCostDecline(startIdx, endIdx) {
     const data = COST_DATA[benchKey];
     if (!data) continue;
 
-    let startEntry = null, endEntry = null;
-    for (let i = startIdx; i >= 0; i--) {
-      if (data.entries[i]) { startEntry = data.entries[i]; break; }
+    // Bug fix: search forward from startIdx to find the first entry in range
+    let startEntry = null, startQ = null;
+    for (let i = startIdx; i <= endIdx; i++) {
+      if (data.entries[i]) { startEntry = data.entries[i]; startQ = TIME_LABELS[i]; break; }
     }
-    for (let i = endIdx; i >= 0; i--) {
-      if (data.entries[i]) { endEntry = data.entries[i]; break; }
+    let endEntry = null, endQ = null;
+    for (let i = endIdx; i >= startIdx; i--) {
+      if (data.entries[i]) { endEntry = data.entries[i]; endQ = TIME_LABELS[i]; break; }
     }
 
-    if (!startEntry || !endEntry || startEntry.price <= 0 || endEntry.price <= 0) {
-      results.push({ benchmark: meta.name, threshold: meta.thresholdLabel, cheaperMultiple: null, description: meta.description, context: meta.context });
+    if (!startEntry || !endEntry || startEntry === endEntry || startEntry.price <= 0 || endEntry.price <= 0) {
+      results.push({ benchmark: meta.name, benchKey, threshold: meta.thresholdLabel, decline: null });
       continue;
     }
 
-    const multiple = Math.round((startEntry.price / endEntry.price) * 10) / 10;
+    const decline = Math.round((startEntry.price / endEntry.price) * 10) / 10;
     results.push({
       benchmark: meta.name,
+      benchKey,
       threshold: meta.thresholdLabel,
+      decline: `${decline}x`,
       startPrice: startEntry.price,
       endPrice: endEntry.price,
       startModel: startEntry.model,
       endModel: endEntry.model,
-      cheaperMultiple: multiple,
-      description: meta.description,
-      context: meta.context,
+      startQ,
+      endQ,
     });
   }
   return results;
+}
+
+function computeDataFreshness(endIdx) {
+  const filterEnd = getFilterEndDate();
+  const activeBenchKeys = Object.keys(BENCHMARKS).filter(k => isBenchmarkActive(k, filterEnd));
+  const freshness = {};
+
+  for (const [labKey, lab] of Object.entries(LABS)) {
+    freshness[lab.name] = {};
+    for (const benchKey of activeBenchKeys) {
+      const bench = BENCHMARKS[benchKey];
+      let latestQ = null;
+      for (let i = endIdx; i >= 0; i--) {
+        if (bench.scores[labKey][i]) {
+          latestQ = TIME_LABELS[i];
+          break;
+        }
+      }
+      freshness[lab.name][bench.name] = latestQ || "no data";
+    }
+  }
+  return freshness;
 }
 
 function getDataForRange(startIdx, endIdx) {
@@ -408,7 +503,6 @@ function computeQuarterRange(preset) {
     return { startIdx: Math.max(0, endIdx - 1), endIdx };
   }
 
-  // Year preset like "2023", "2024", etc.
   const year = parseInt(preset);
   if (!isNaN(year)) {
     const q1Label = `Q1 ${year}`;
@@ -416,7 +510,7 @@ function computeQuarterRange(preset) {
     let si = TIME_LABELS.indexOf(q1Label);
     let ei = TIME_LABELS.indexOf(q4Label);
     if (si < 0) si = 0;
-    if (ei < 0) ei = endIdx; // partial year — clamp to end
+    if (ei < 0) ei = endIdx;
     return { startIdx: si, endIdx: ei };
   }
 
@@ -424,31 +518,125 @@ function computeQuarterRange(preset) {
 }
 
 function getPresets() {
-  // Fixed presets
   const presets = ["all-time", "last-12-months", "last-6-months", "last-3-months"];
 
-  // Year presets from TIME_LABELS
   const years = [...new Set(TIME_LABELS.map(q => q.substring(3)))];
   for (const year of years) {
+    // Skip single-quarter years (e.g. 2026 with only Q1)
+    const quartersInYear = TIME_LABELS.filter(q => q.endsWith(year));
+    if (quartersInYear.length <= 1) continue;
     presets.push(year);
   }
 
   return presets;
 }
 
-// ─── Analysis generation ─────────────────────────────────────
+// ─── Build structured analysis JSON ──────────────────────────
+
+function buildCallouts(startIdx, endIdx) {
+  // For frontier stats: use trailing 12-month window when range > 4 quarters
+  const rangeQuarters = endIdx - startIdx;
+  const frontierStartIdx = rangeQuarters > 4 ? Math.max(0, endIdx - 4) : startIdx;
+  const frontierGrowth = computeFrontierGrowth(frontierStartIdx, endIdx);
+
+  // For race stats: also use trailing 12-month window for comparison
+  const raceCompareIdx = rangeQuarters > 4 ? Math.max(0, endIdx - 4) : startIdx;
+  const rankings = computeRankings(raceCompareIdx, endIdx);
+  const raceMonthsBack = (endIdx - raceCompareIdx) * 3;
+
+  const costDecline = computeCostDecline(startIdx, endIdx);
+
+  // Defeated benchmarks in this period (uses full range, not trailing)
+  const startQ = TIME_LABELS[startIdx];
+  const endQ = TIME_LABELS[endIdx];
+  const defeatedThisPeriod = [];
+  for (const [benchKey, meta] of Object.entries(BENCHMARK_META)) {
+    if (!meta.activeUntil) continue;
+    if (compareQuarters(meta.activeUntil, startQ) >= 0 && compareQuarters(meta.activeUntil, endQ) <= 0) {
+      defeatedThisPeriod.push({ name: meta.name, reason: meta.inactiveReason });
+    }
+  }
+
+  // Frontier callouts
+  const frontierMonths = (endIdx - frontierStartIdx) * 3;
+  const periodSuffix = frontierMonths > 0 ? ` over the last ${frontierMonths} months` : "";
+  const frontier = {
+    callouts: {
+      medianIncrease: {
+        value: `${frontierGrowth.medianRelPct}%`,
+        label: "median increase",
+        detail: `across ${frontierGrowth.benchmarks.length} active benchmarks${periodSuffix}`,
+      },
+    },
+  };
+  if (frontierGrowth.biggestMover) {
+    const bm = frontierGrowth.biggestMover;
+    frontier.callouts.biggestMover = {
+      name: bm.benchmark,
+      ppChange: bm.ppChange,
+      periodLabel: periodSuffix.trim(),
+    };
+  }
+  if (defeatedThisPeriod.length > 0) {
+    frontier.callouts.benchmarksSaturated = {
+      count: defeatedThisPeriod.length,
+      names: defeatedThisPeriod.map(d => d.name),
+    };
+  }
+
+  // Race callouts
+  const race = { callouts: {} };
+  if (rankings.leader) {
+    const l = rankings.leader;
+    const direction = l.startAvgRank !== null
+      ? (l.endAvgRank < l.startAvgRank ? "down" : l.endAvgRank > l.startAvgRank ? "up" : "unchanged")
+      : null;
+    race.callouts.leader = {
+      name: l.lab,
+      avgRank: l.endAvgRank,
+      firsts: l.endFirsts,
+      benchmarkCount: l.benchmarksRanked,
+      startAvgRank: l.startAvgRank,
+      direction,
+      monthsBack: raceMonthsBack,
+    };
+  }
+  if (rankings.biggestMover) {
+    const m = rankings.biggestMover;
+    const change = Math.round(m.change * 10) / 10;
+    const direction = change < 0 ? "improved" : "worsened";
+    race.callouts.biggestMover = {
+      name: m.lab,
+      avgRank: m.endAvgRank,
+      change,
+      direction,
+      firsts: m.endFirsts,
+      benchmarkCount: rankings.leader ? rankings.leader.benchmarksRanked : m.benchmarksRanked,
+      monthsBack: raceMonthsBack,
+    };
+  }
+
+  // Cost callouts
+  const cost = {
+    callouts: costDecline.filter(c => c.decline !== null),
+    explanation: "Shows the cheapest model (any lab) scoring above a fixed threshold on each benchmark, measured in $/M tokens (blended 3:1 input:output). Thresholds are set at what the best model scored when each benchmark launched.",
+  };
+
+  return { frontier, race, cost };
+}
 
 async function generateAnalysis(preset) {
   const { startIdx, endIdx } = computeQuarterRange(preset);
   const startQ = TIME_LABELS[startIdx];
   const endQ = TIME_LABELS[endIdx];
 
+  const callouts = buildCallouts(startIdx, endIdx);
+  const perQuarterFrontier = computePerQuarterFrontier(startIdx, endIdx);
+  const freshness = computeDataFreshness(endIdx);
   const benchmarkData = getDataForRange(startIdx, endIdx);
-  const frontierGrowth = computeFrontierGrowth(startIdx, endIdx);
-  const rankings = computeRankings(startIdx, endIdx);
+
   const filterEnd = getFilterEndDate();
   const activeBenchKeys = Object.keys(BENCHMARKS).filter(k => isBenchmarkActive(k, filterEnd));
-
   const labCoverage = {};
   for (const [labKey, lab] of Object.entries(LABS)) {
     let has = 0;
@@ -459,41 +647,24 @@ async function generateAnalysis(preset) {
     labCoverage[lab.name] = `${has}/${activeBenchKeys.length} active benchmarks`;
   }
 
-  const defeatedThisPeriod = [];
-  for (const [benchKey, meta] of Object.entries(BENCHMARK_META)) {
-    if (!meta.activeUntil) continue;
-    if (compareQuarters(meta.activeUntil, startQ) >= 0 && compareQuarters(meta.activeUntil, endQ) <= 0) {
-      defeatedThisPeriod.push({
-        name: meta.name,
-        status: meta.status,
-        activeUntil: meta.activeUntil,
-        reason: meta.inactiveReason,
-      });
-    }
-  }
+  const userPrompt = `=== CALLOUT STATS (code-computed, displayed to user — reference these numbers) ===
+${JSON.stringify(callouts, null, 2)}
 
-  const stats = {
-    frontierGrowth,
-    leader: rankings.leader,
-    biggestLoser: rankings.biggestLoser,
-    activeBenchmarkCount: frontierGrowth.benchmarks.length,
-    labDataCoverage: labCoverage,
-    defeatedThisPeriod,
-  };
-  const costData = computeCostDecline(startIdx, endIdx);
+=== PER-QUARTER FRONTIER SCORES (best across all labs per benchmark per quarter) ===
+${JSON.stringify(perQuarterFrontier, null, 2)}
 
-  const userPrompt = `=== PRE-COMPUTED STATISTICS ===
-${JSON.stringify(stats, null, 2)}
+=== DATA FRESHNESS (most recent quarter with data per lab per benchmark) ===
+${JSON.stringify(freshness, null, 2)}
 
-=== COST OF INTELLIGENCE ===
-${JSON.stringify(costData, null, 2)}
+=== LAB DATA COVERAGE ===
+${JSON.stringify(labCoverage, null, 2)}
 
 === RAW BENCHMARK SCORES (${startQ} to ${endQ}) ===
 ${benchmarkData}`;
 
   const message = await anthropic.messages.create({
     model: "claude-opus-4-6",
-    max_tokens: 2048,
+    max_tokens: 1024,
     system: SYSTEM_PROMPT,
     messages: [{ role: "user", content: userPrompt }],
   });
@@ -501,9 +672,40 @@ ${benchmarkData}`;
   const text = message.content
     .filter((block) => block.type === "text")
     .map((block) => block.text)
-    .join("\n");
+    .join("");
 
-  return { analysis: text, startQuarter: startQ, endQuarter: endQ };
+  // Parse LLM JSON response
+  let llmOutput;
+  try {
+    // Strip markdown code fences if present
+    const cleaned = text.replace(/^```json\s*\n?/i, "").replace(/\n?```\s*$/i, "").trim();
+    llmOutput = JSON.parse(cleaned);
+  } catch (err) {
+    console.error(`   Failed to parse LLM JSON response:`);
+    console.error(`   Raw text: ${text.substring(0, 500)}`);
+    throw new Error(`LLM returned invalid JSON: ${err.message}`);
+  }
+
+  // Merge callout stats with LLM commentary
+  const analysis = {
+    frontier: {
+      ...callouts.frontier,
+      headline: llmOutput.frontier?.headline || "",
+      commentary: llmOutput.frontier?.commentary || "",
+    },
+    race: {
+      ...callouts.race,
+      headline: llmOutput.race?.headline || "",
+      commentary: llmOutput.race?.commentary || "",
+    },
+    cost: {
+      ...callouts.cost,
+      headline: llmOutput.cost?.headline || "",
+      commentary: llmOutput.cost?.commentary || "",
+    },
+  };
+
+  return { analysis: JSON.stringify(analysis), startQuarter: startQ, endQuarter: endQ };
 }
 
 // ─── Main ────────────────────────────────────────────────────
@@ -514,7 +716,9 @@ async function main() {
   console.log(`   Loaded ${Object.keys(BENCHMARKS).length} benchmarks, ${Object.keys(COST_DATA).length} cost benchmarks`);
   console.log(`   TIME_LABELS: ${TIME_LABELS[0]} to ${TIME_LABELS[TIME_LABELS.length - 1]} (${TIME_LABELS.length} quarters)\n`);
 
-  const presets = getPresets();
+  // Allow running a single preset via CLI arg
+  const cliPreset = process.argv[2];
+  const presets = cliPreset ? [cliPreset] : getPresets();
   console.log(`2. Generating analyses for ${presets.length} presets: ${presets.join(", ")}\n`);
 
   for (const preset of presets) {

--- a/styles.css
+++ b/styles.css
@@ -462,32 +462,72 @@ main {
   border-radius: var(--radius-lg);
   padding: 1rem 1.25rem;
   margin-bottom: 0.75rem;
+  position: relative;
 }
 
-.analysis-heading {
+/* Copy button — top-right of card */
+.analysis-card > .copy-icon-btn {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+}
+
+/* Callout stats list */
+.callout-stats {
   display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-  margin-bottom: 0.5rem;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+  list-style: none;
+  padding: 0;
 }
 
-.analysis-heading h2 {
-  font-size: 1rem;
+.callout-line {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  display: flex;
+  gap: 0.4rem;
+  align-items: baseline;
+}
+
+.callout-line::before {
+  content: "\2022";
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.callout-obj {
   font-weight: 600;
   color: var(--text-primary);
 }
 
-.section-header {
+.callout-num {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.analysis-headline {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  margin-bottom: 0.35rem;
+  line-height: 1.5;
+}
+
+.analysis-commentary {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin-bottom: 0.5rem;
+}
+
+.analysis-footer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.5rem;
-}
-
-.section-header h3 {
-  font-size: 0.925rem;
-  font-weight: 600;
-  color: var(--text-primary);
+  border-top: 1px solid var(--border);
+  padding-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .copy-icon-btn {
@@ -508,35 +548,6 @@ main {
   color: var(--text-primary);
   border-color: var(--border);
   background: var(--bg-tertiary);
-}
-
-.headline-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.headline-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.headline-item:last-child {
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.headline-text {
-  flex: 1;
-  color: var(--text-primary);
-  font-size: 0.875rem;
-  line-height: 1.55;
 }
 
 .analysis-loading-inline {
@@ -613,80 +624,10 @@ main {
   to { transform: rotate(360deg); }
 }
 
-.analysis-text {
-  color: var(--text-primary);
-  font-size: 0.875rem;
-  line-height: 1.7;
-}
-
-.analysis-text h2 {
-  font-size: 1rem;
-  font-weight: 600;
-  margin: 0.75rem 0 0.35rem;
-}
-
-.analysis-text h2:first-child {
-  margin-top: 0;
-}
-
-.analysis-text strong {
-  color: var(--accent);
-}
-
-.analysis-text ul {
-  padding-left: 1.25rem;
-  margin: 0.35rem 0;
-}
-
-.analysis-text li {
-  margin-bottom: 0.25rem;
-}
-
-.analysis-text p {
-  margin-bottom: 0.5rem;
-}
-
-/* Cost of Intelligence info area */
-.cost-headlines {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.cost-headline-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.cost-headline-label {
-  font-weight: 500;
-  color: var(--text-primary);
-  font-size: 0.875rem;
-}
-
-.cost-decline {
-  color: #10b981;
-  font-weight: 700;
-  font-size: 0.9rem;
-}
-
-.cost-range {
+/* Cost callout styling */
+.callout-line .cost-range {
   color: var(--text-muted);
   font-size: 0.8rem;
-}
-
-.cost-explanation {
-  border-top: 1px solid var(--border);
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
-}
-
-.cost-explanation p {
-  color: var(--text-secondary);
-  font-size: 0.8rem;
-  line-height: 1.55;
 }
 
 /* Inactive benchmark tooltip */


### PR DESCRIPTION
## Summary

- **Replaces markdown prose analysis** with code-computed structured stat cards + short LLM-generated headlines and commentary, stored as JSON
- **Mode-specific rendering**: each tab (frontier, race, cost) shows its own analysis card with bullet-point callout stats, a headline, and 1-2 sentence commentary
- **Trailing 12-month window** for frontier and race stats when viewing periods longer than 12 months, so numbers stay meaningful
- **Unified info area**: all modes now use the same collapsible benchmark list format with methodology intro
- **Cost benchmark descriptions** rewritten with proper detail and arxiv links
- **Single-quarter year presets** (e.g. 2026 with only Q1) filtered from dropdown and generation
- **Cleaned up** old markdown rendering code and unused CSS classes

## Files changed

- `app.js` — new `renderAnalysisCard()`, unified `renderInfoArea()`, JSON parsing, removed old markdown rendering
- `scripts/generate-analyses.js` — structured JSON output, stat computation fixes (cost bug, forward search), trailing window logic
- `lib/analysis-prompt.js` — complete rewrite for JSON-only output with headline + commentary
- `data-loader.js` — improved cost benchmark descriptions and links
- `styles.css` — new callout/bullet styles, removed old headline/section classes

## Test plan

- [ ] Verify all 7 presets render correctly (all-time, last-12-months, last-6-months, last-3-months, 2023, 2024, 2025)
- [ ] Switch between frontier/race/cost modes — analysis card re-renders without refetch
- [ ] Switch date ranges — analysis refetches and re-renders
- [ ] Verify cost mode info area shows collapsible benchmark descriptions (all collapsed by default)
- [ ] Verify copy button copies clean plain text
- [ ] Verify 2026 is not in the date range dropdown
- [ ] Spot-check LLM headlines don't just restate the stat numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)