### PR TITLE
Add data model, DB-driven model cards, post-insert verification (Phase 2)

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -164,6 +164,37 @@ function computeCumulativeMin(dataPoints, quarters) {
   return result;
 }
 
+// ─── Regex generation for verified matching ─────────────────
+
+/**
+ * Auto-generate a matchVerified regex from a model name.
+ * E.g., "GPT-5.4 Mini" -> /gpt.?5[\.\s-]?4.?mini/i
+ * Handles version numbers (dots/dashes between digits) and whitespace/punctuation.
+ */
+function generateMatchVerifiedRegex(modelName) {
+  // Normalize: lowercase, strip parentheticals like "(with tools)"
+  const cleaned = modelName.replace(/\s*\(.*?\)\s*/g, "").trim().toLowerCase();
+
+  // Build regex: replace separators with flexible matchers
+  let pattern = "";
+  for (let i = 0; i < cleaned.length; i++) {
+    const ch = cleaned[i];
+    if (/[a-z0-9]/.test(ch)) {
+      pattern += ch;
+      // After a digit followed by a dot/dash/space + digit, insert flexible separator
+      if (/[0-9]/.test(ch) && i + 1 < cleaned.length && /[.\-\s]/.test(cleaned[i + 1]) && i + 2 < cleaned.length && /[0-9]/.test(cleaned[i + 2])) {
+        pattern += "[.\\s-]?";
+        i++; // Skip the separator
+      }
+    } else if (/[\s.\-]/.test(ch)) {
+      pattern += ".?";
+    }
+    // Other chars (punctuation) are skipped
+  }
+
+  return new RegExp(pattern, "i");
+}
+
 // ─── CSV column finder ───────────────────────────────────────
 
 function findCol(headers, preferred, candidates) {
@@ -188,5 +219,6 @@ module.exports = {
   filterVerifiedDuplicates,
   computeCumulativeBest,
   computeCumulativeMin,
+  generateMatchVerifiedRegex,
   findCol,
 };

--- a/migrations/001-add-extraction-columns.sql
+++ b/migrations/001-add-extraction-columns.sql
@@ -1,0 +1,6 @@
+-- Migration 001: Add columns for automated model card extraction pipeline.
+-- Run in Supabase SQL editor.
+
+ALTER TABLE benchmark_raw ADD COLUMN IF NOT EXISTS source_url TEXT;
+ALTER TABLE benchmark_raw ADD COLUMN IF NOT EXISTS raw_benchmark_name TEXT;
+ALTER TABLE benchmark_raw ADD COLUMN IF NOT EXISTS extracted_at TIMESTAMPTZ DEFAULT NOW();

--- a/scripts/migrate-model-cards.js
+++ b/scripts/migrate-model-cards.js
@@ -1,0 +1,102 @@
+// scripts/migrate-model-cards.js
+// One-time migration: inserts existing hardcoded MODEL_CARD_DATA entries into
+// benchmark_raw with source_url and raw_benchmark_name backfilled.
+// Safe to re-run (uses upsert on benchmark,lab,model,source).
+//
+// Usage:
+//   SUPABASE_SERVICE_KEY=xxx node scripts/migrate-model-cards.js
+
+const { createClient } = require("@supabase/supabase-js");
+
+const SUPABASE_URL = process.env.SUPABASE_URL || "https://jtrhsqdfevyqzzjjvcdr.supabase.co";
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
+
+if (!SUPABASE_SERVICE_KEY) {
+  console.error("Error: Set SUPABASE_SERVICE_KEY environment variable.");
+  process.exit(1);
+}
+
+// Blog post URLs per model release (source of each model card entry)
+const SOURCE_URLS = {
+  "GPT-5.4":          "https://openai.com/index/introducing-gpt-5-4/",
+  "Claude Sonnet 4.6": "https://www.anthropic.com/claude/sonnet",
+  "Claude Opus 4.6":  "https://www.anthropic.com/news/claude-opus-4-6",
+  "Gemini 3 Deep Think": "https://blog.google/technology/google-deepmind/gemini-3-deep-think/",
+  "Gemini 3.1 Pro":   "https://blog.google/technology/google-deepmind/gemini-3-1-pro/",
+};
+
+// Raw benchmark names as they appear on model cards
+const RAW_BENCHMARK_NAMES = {
+  "hle":        "Humanity's Last Exam",
+  "gpqa":       "GPQA Diamond",
+  "arc-agi-2":  "ARC-AGI-2",
+  "arc-agi-1":  "ARC-AGI-1",
+  "swe-bench":  "SWE-bench Verified",
+};
+
+// The 17 hardcoded model card entries (same data as MODEL_CARD_DATA in update-data.js)
+const ENTRIES = [
+  // GPT-5.4
+  { benchmark: "hle", lab: "openai", model: "GPT-5.4 Pro (with tools)", score: 58.7, date: "2026-03-05", modelFamily: "GPT-5.4" },
+  { benchmark: "gpqa", lab: "openai", model: "GPT-5.4 Pro", score: 94.4, date: "2026-03-05", modelFamily: "GPT-5.4" },
+  { benchmark: "arc-agi-2", lab: "openai", model: "GPT-5.4 Pro", score: 83.3, date: "2026-03-05", modelFamily: "GPT-5.4" },
+  { benchmark: "arc-agi-1", lab: "openai", model: "GPT-5.4 Pro", score: 94.5, date: "2026-03-05", modelFamily: "GPT-5.4" },
+
+  // Claude Sonnet 4.6
+  { benchmark: "gpqa", lab: "anthropic", model: "Claude Sonnet 4.6", score: 89.9, date: "2026-02-17", modelFamily: "Claude Sonnet 4.6" },
+  { benchmark: "swe-bench", lab: "anthropic", model: "Claude Sonnet 4.6", score: 79.6, date: "2026-02-17", modelFamily: "Claude Sonnet 4.6" },
+  { benchmark: "arc-agi-2", lab: "anthropic", model: "Claude Sonnet 4.6", score: 58.3, date: "2026-02-17", modelFamily: "Claude Sonnet 4.6" },
+  { benchmark: "hle", lab: "anthropic", model: "Claude Sonnet 4.6 (with tools)", score: 49.0, date: "2026-02-17", modelFamily: "Claude Sonnet 4.6" },
+
+  // Claude Opus 4.6
+  { benchmark: "gpqa", lab: "anthropic", model: "Claude Opus 4.6", score: 91.3, date: "2026-03-01", modelFamily: "Claude Opus 4.6" },
+  { benchmark: "swe-bench", lab: "anthropic", model: "Claude Opus 4.6", score: 80.8, date: "2026-03-01", modelFamily: "Claude Opus 4.6" },
+  { benchmark: "hle", lab: "anthropic", model: "Claude Opus 4.6 (with tools)", score: 53.0, date: "2026-03-01", modelFamily: "Claude Opus 4.6" },
+  { benchmark: "arc-agi-2", lab: "anthropic", model: "Claude Opus 4.6", score: 68.8, date: "2026-03-01", modelFamily: "Claude Opus 4.6" },
+
+  // Gemini 3 Deep Think
+  { benchmark: "hle", lab: "google", model: "Gemini 3 Deep Think (with tools)", score: 53.4, date: "2026-02-12", modelFamily: "Gemini 3 Deep Think" },
+  { benchmark: "hle", lab: "google", model: "Gemini 3 Deep Think", score: 48.4, date: "2026-02-12", modelFamily: "Gemini 3 Deep Think" },
+  { benchmark: "arc-agi-2", lab: "google", model: "Gemini 3 Deep Think", score: 84.6, date: "2026-02-12", modelFamily: "Gemini 3 Deep Think" },
+
+  // Gemini 3.1 Pro
+  { benchmark: "gpqa", lab: "google", model: "Gemini 3.1 Pro", score: 94.3, date: "2026-02-19", modelFamily: "Gemini 3.1 Pro" },
+  { benchmark: "hle", lab: "google", model: "Gemini 3.1 Pro (with tools)", score: 51.4, date: "2026-02-19", modelFamily: "Gemini 3.1 Pro" },
+  { benchmark: "hle", lab: "google", model: "Gemini 3.1 Pro", score: 44.4, date: "2026-02-19", modelFamily: "Gemini 3.1 Pro" },
+  { benchmark: "arc-agi-2", lab: "google", model: "Gemini 3.1 Pro", score: 77.1, date: "2026-02-19", modelFamily: "Gemini 3.1 Pro" },
+];
+
+async function main() {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+  const rows = ENTRIES.map(e => ({
+    benchmark: e.benchmark,
+    lab: e.lab,
+    model: e.model,
+    score: e.score,
+    date: e.date,
+    source: "model_card",
+    verified: false,
+    source_url: SOURCE_URLS[e.modelFamily] || null,
+    raw_benchmark_name: RAW_BENCHMARK_NAMES[e.benchmark] || null,
+    extracted_at: new Date().toISOString(),
+  }));
+
+  console.log(`Upserting ${rows.length} model card entries to benchmark_raw...`);
+
+  const { error } = await supabase
+    .from("benchmark_raw")
+    .upsert(rows, { onConflict: "benchmark,lab,model,source" });
+
+  if (error) {
+    console.error("Upsert FAILED:", error.message);
+    process.exit(1);
+  }
+
+  console.log(`Done. ${rows.length} rows upserted.`);
+}
+
+main().catch(err => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/scripts/update-data.js
+++ b/scripts/update-data.js
@@ -37,7 +37,7 @@ const {
   normalizeOrg, quarterEndDate, extractDateFromModelId,
   arcModelIdToLab, modelNameToLab,
   filterVerifiedDuplicates, computeCumulativeBest, computeCumulativeMin,
-  findCol,
+  generateMatchVerifiedRegex, findCol,
 } = require("../lib/pipeline.js");
 
 // Current quarter midpoint for ARC Prize entries without extractable dates
@@ -105,6 +105,40 @@ const MODEL_CARD_DATA = [
   { benchmark: "hle", lab: "google", model: "Gemini 3.1 Pro", score: 44.4, date: new Date("2026-02-19"), source: "model_card", verified: false, matchVerified: /gemini.?3[\.\s-]?1.?pro/i },
   { benchmark: "arc-agi-2", lab: "google", model: "Gemini 3.1 Pro", score: 77.1, date: new Date("2026-02-19"), source: "model_card", verified: false, matchVerified: /gemini.?3[\.\s-]?1.?pro/i },
 ];
+
+// ─── Source 7: Model cards from Supabase (DB-driven path) ────
+
+/**
+ * Fetch model card data from benchmark_raw where source is 'model_card' or 'model_card_auto'.
+ * Returns same shape as MODEL_CARD_DATA for drop-in replacement.
+ */
+async function fetchModelCardData(supabase) {
+  const { data, error } = await supabase
+    .from("benchmark_raw")
+    .select("benchmark, lab, model, score, date, source, verified")
+    .in("source", ["model_card", "model_card_auto"]);
+
+  if (error) {
+    console.warn("   [ModelCards] WARN: Failed to fetch from DB:", error.message);
+    return null; // Caller falls back to hardcoded
+  }
+
+  if (!data || data.length === 0) {
+    console.warn("   [ModelCards] WARN: No model card rows in DB");
+    return null;
+  }
+
+  return data.map(row => ({
+    benchmark: row.benchmark,
+    lab: row.lab,
+    model: row.model,
+    score: row.score,
+    date: new Date(row.date),
+    source: row.source,
+    verified: row.verified === true,
+    matchVerified: generateMatchVerifiedRegex(row.model),
+  }));
+}
 
 // ─── HTTP helpers ────────────────────────────────────────────
 
@@ -658,9 +692,17 @@ async function main() {
     fetchCostData().catch(err => { console.error("   [Cost] FAILED:", err.message); return []; }),
   ]);
 
-  // Merge all data points, filter model card duplicates, then group by benchmark
+  // Fetch model card data: try DB first, fall back to hardcoded
   console.log("\n2. Merging data and computing cumulative best...");
-  const allMerged = [...aaData, ...sweData, ...arcData, ...epochData, ...MODEL_CARD_DATA];
+  const dbModelCards = await fetchModelCardData(supabase);
+  const modelCardData = dbModelCards || MODEL_CARD_DATA;
+  if (dbModelCards) {
+    console.log(`   Using ${dbModelCards.length} model card entries from DB`);
+  } else {
+    console.log(`   Using ${MODEL_CARD_DATA.length} hardcoded model card entries (DB fallback)`);
+  }
+
+  const allMerged = [...aaData, ...sweData, ...arcData, ...epochData, ...modelCardData];
   const allFiltered = filterVerifiedDuplicates(allMerged);
 
   const byBenchmark = {}; // { benchKey: { labKey: [dataPoints] } }
@@ -802,6 +844,33 @@ async function main() {
   }
 
   console.log(`   Inserted ${allRows.length} rows successfully.`);
+
+  // Post-insert verification: check row counts per benchmark
+  console.log("   Verifying post-insert row counts...");
+  let verifyFailed = false;
+  for (const benchKey of automatedBenchmarks) {
+    const { count, error: countErr } = await supabase
+      .from("benchmark_scores")
+      .select("*", { count: "exact", head: true })
+      .eq("benchmark", benchKey);
+
+    if (countErr) {
+      console.error(`   VERIFY ERROR: Could not count rows for ${benchKey}: ${countErr.message}`);
+      verifyFailed = true;
+    } else if (count === 0) {
+      console.error(`   VERIFY FAILED: ${benchKey} has 0 rows after insert!`);
+      verifyFailed = true;
+    } else {
+      const expectedMin = LAB_KEYS.length * QUARTERS.length;
+      if (count < expectedMin) {
+        console.warn(`   VERIFY WARN: ${benchKey} has ${count} rows (expected >= ${expectedMin})`);
+      }
+    }
+  }
+  if (verifyFailed) {
+    console.error("\n   POST-INSERT VERIFICATION FAILED. The site may be showing incomplete data.");
+    console.error("   Re-run this script or investigate the benchmark_scores table.");
+  }
 
   // ─── Cost of Intelligence processing ────────────────────────
   console.log("\n4. Processing cost data...");

--- a/tests/extraction.test.js
+++ b/tests/extraction.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 
 // Forward-looking tests for Phase 3 extraction functions.
-// These will be filled in when lib/pipeline.js gains normalizeBenchmarkName,
-// triageScore, and generateMatchVerifiedRegex.
+// normalizeBenchmarkName and triageScore will be filled in during Phase 3.
+// generateMatchVerifiedRegex tests are now in pipeline.test.js (implemented in Phase 2).
 
 describe("normalizeBenchmarkName (placeholder)", () => {
   it.todo("exact matches: 'GPQA Diamond' -> gpqa");
@@ -16,9 +16,4 @@ describe("triageScore (placeholder)", () => {
   it.todo("auto-reject: nonsensical score (<0 or >100)");
   it.todo("flag-for-review: >10pp above current best");
   it.todo("flag-for-review: fuzzy benchmark match");
-});
-
-describe("generateMatchVerifiedRegex (placeholder)", () => {
-  it.todo("produces correct pattern for 'GPT-5.4 Mini'");
-  it.todo("produces correct pattern for 'Claude Sonnet 4.6'");
 });

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -9,6 +9,7 @@ const {
   filterVerifiedDuplicates,
   computeCumulativeBest,
   computeCumulativeMin,
+  generateMatchVerifiedRegex,
   findCol,
 } = require("../lib/pipeline.js");
 
@@ -328,5 +329,46 @@ describe("findCol", () => {
 
   it("returns null with null preferred and no candidate matches", () => {
     expect(findCol(headers, null, ["x", "y", "z"])).toBeNull();
+  });
+});
+
+// ─── generateMatchVerifiedRegex ──────────────────────────────
+
+describe("generateMatchVerifiedRegex", () => {
+  it("matches the model name it was generated from", () => {
+    const re = generateMatchVerifiedRegex("GPT-5.4 Pro");
+    expect(re.test("GPT-5.4 Pro")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    const re = generateMatchVerifiedRegex("GPT-5.4 Mini");
+    expect(re.test("gpt-5.4 mini")).toBe(true);
+    expect(re.test("GPT-5.4 MINI")).toBe(true);
+  });
+
+  it("handles version number separators flexibly", () => {
+    const re = generateMatchVerifiedRegex("Claude Sonnet 4.6");
+    expect(re.test("Claude Sonnet 4.6")).toBe(true);
+    expect(re.test("claude sonnet 4-6")).toBe(true);
+    expect(re.test("claude sonnet 4 6")).toBe(true);
+    expect(re.test("claude-sonnet-4.6")).toBe(true);
+  });
+
+  it("strips parenthetical suffixes like '(with tools)'", () => {
+    const re = generateMatchVerifiedRegex("GPT-5.4 Pro (with tools)");
+    expect(re.test("GPT-5.4 Pro")).toBe(true);
+    expect(re.test("gpt 5.4 pro")).toBe(true);
+  });
+
+  it("produces patterns that match real model names", () => {
+    expect(generateMatchVerifiedRegex("Gemini 3.1 Pro").test("Gemini 3.1 Pro")).toBe(true);
+    expect(generateMatchVerifiedRegex("Gemini 3 Deep Think").test("Gemini 3 Deep Think")).toBe(true);
+    expect(generateMatchVerifiedRegex("Claude Opus 4.6").test("claude opus 4.6")).toBe(true);
+  });
+
+  it("does not match unrelated models", () => {
+    const re = generateMatchVerifiedRegex("GPT-5.4 Pro");
+    expect(re.test("Claude Sonnet 4.6")).toBe(false);
+    expect(re.test("Gemini 3.1 Pro")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- **Schema migration SQL** (`migrations/001-add-extraction-columns.sql`): adds `source_url`, `raw_benchmark_name`, `extracted_at` columns to `benchmark_raw`
- **Model card seed script** (`scripts/migrate-model-cards.js`): one-time migration to insert the 17 hardcoded model card entries into `benchmark_raw` with source URLs
- **`generateMatchVerifiedRegex()`** in `lib/pipeline.js`: auto-generates verified match patterns from model names (e.g., "Claude Sonnet 4.6" -> `/claude.?sonnet.?4[.\s-]?6/i`)
- **`fetchModelCardData()`** in `update-data.js`: reads model cards from Supabase DB, falls back to hardcoded `MODEL_CARD_DATA` if DB is empty
- **Post-insert verification**: after benchmark_scores insert, checks row counts per benchmark and warns if any are zero
- 6 new tests for regex generation (62 total passing)

## Manual steps required after merge
1. Run the migration SQL in Supabase SQL editor (copy from `migrations/001-add-extraction-columns.sql`)
2. Run the seed script: `node scripts/migrate-model-cards.js`
3. Run `node scripts/update-data.js` and confirm output matches pre-migration behavior

## Test plan
- [x] `npx vitest run` -- 62 pass, 8 todo
- [x] Both scripts load without errors (syntax check)
- [x] Auto-generated regex matches all existing model names correctly
- [ ] Run migration SQL in Supabase
- [ ] Run seed script
- [ ] Run `update-data.js` and compare output

🤖 Generated with [Claude Code](https://claude.com/claude-code)