### PR TITLE
Fix 5 issues from first automated pipeline run

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,6 +34,7 @@ jobs:
         run: node scripts/validate-extraction.mjs
 
       - name: Run pipeline
+        id: pipeline
         env:
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           AA_API_KEY: ${{ secrets.AA_API_KEY }}
@@ -42,14 +43,25 @@ jobs:
         run: node scripts/run-pipeline.mjs
 
       - name: Regenerate analyses
+        id: analyses
         if: success()
         env:
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: node scripts/generate-analyses.js
 
-      - name: Notify on failure
-        if: failure()
+      - name: Report analysis failures
+        if: always() && steps.analyses.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUM=$(gh issue list --label pipeline-report --limit 1 --json number --jq '.[0].number')
+          if [ -n "$ISSUE_NUM" ]; then
+            gh issue comment "$ISSUE_NUM" --body "**Analysis regeneration failed.** Some presets may be serving stale data. Check the [Actions log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi
+
+      - name: Notify on pipeline failure
+        if: failure() && steps.pipeline.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/extract-model-cards.mjs
+++ b/scripts/extract-model-cards.mjs
@@ -150,8 +150,9 @@ async function launchBrowser() {
  */
 async function scanBlogIndex(page, source) {
   console.log(`   Scanning ${source.name} (${source.indexUrl})...`);
-  await page.goto(source.indexUrl, { waitUntil: "load", timeout: 45000 });
-  await page.waitForTimeout(3000);
+  await page.goto(source.indexUrl, { waitUntil: "domcontentloaded", timeout: 45000 });
+  // Wait for JS frameworks (React, Next.js) to hydrate — matches extractPageContent() timing
+  await page.waitForTimeout(6000);
 
   let articles = await page.evaluate(() => {
     const links = Array.from(document.querySelectorAll("a[href]"));
@@ -408,12 +409,24 @@ async function downloadImage(url) {
  * Extract all benchmark scores from a single article.
  * Downloads images in parallel, runs vision + text extraction concurrently.
  */
-async function extractFromArticle(page, anthropic, url, modelName) {
+async function extractFromArticle(page, anthropic, url, modelName, cutoffDate = null) {
   console.log(`\n   Extracting: "${modelName}" from ${url}`);
 
   // Step 1: Extract page content
   const { publishDate, images, sections, dateString } = await extractPageContent(page, url);
   console.log(`     Publish date: ${publishDate ? publishDate.toISOString().split("T")[0] : `not found (raw: ${dateString})`}`);
+
+  // Date filtering: skip LLM extraction for articles older than cutoff
+  if (cutoffDate && publishDate && publishDate < cutoffDate) {
+    const pubStr = publishDate.toISOString().split("T")[0];
+    const cutStr = cutoffDate.toISOString().split("T")[0];
+    console.log(`     Skipping (published ${pubStr}, before cutoff ${cutStr})`);
+    return { scores: [], publishDate, skippedOld: true };
+  }
+  if (cutoffDate && !publishDate) {
+    console.log(`     Date not parseable, processing anyway (fail open)`);
+  }
+
   console.log(`     Found ${images.length} images, ${sections.length} text sections`);
 
   // Step 2: Filter and download content images
@@ -634,10 +647,11 @@ async function main() {
       const articlePage = await ctx.newPage();
 
       try {
-        const { scores, publishDate } = await extractFromArticle(
-          articlePage, anthropic, article.url, article.modelName
+        const cutoff = FORCE ? null : lastExtractionDate;
+        const { scores, publishDate, skippedOld } = await extractFromArticle(
+          articlePage, anthropic, article.url, article.modelName, cutoff
         );
-        allExtracted.push({ article, scores, publishDate });
+        allExtracted.push({ article, scores, publishDate, skippedOld });
       } catch (err) {
         console.error(`   FAILED: ${article.title}: ${err.message.substring(0, 200)}`);
         allExtracted.push({ article, scores: [], publishDate: null });
@@ -648,6 +662,18 @@ async function main() {
   } finally {
     await browser.close();
     console.log("\nBrowser closed.\n");
+  }
+
+  // Log date filtering summary
+  const skippedOldCount = allExtracted.filter(e => e.skippedOld).length;
+  const processedCount = allExtracted.filter(e => !e.skippedOld).length;
+  const noParseDateCount = allExtracted.filter(e => !e.skippedOld && !e.publishDate).length;
+  if (skippedOldCount > 0) {
+    console.log(`   ${skippedOldCount} article(s) skipped (before cutoff), ${processedCount} processed`);
+    if (noParseDateCount > 0) {
+      console.log(`   ${noParseDateCount} article(s) with unparseable dates (processed anyway)`);
+    }
+    console.log("");
   }
 
   // ─── Step 3: Normalize, triage, and store ────────────────────

--- a/scripts/generate-analyses.js
+++ b/scripts/generate-analyses.js
@@ -660,31 +660,59 @@ async function main() {
   const presets = cliPreset ? [cliPreset] : getPresets();
   console.log(`2. Generating analyses for ${presets.length} presets: ${presets.join(", ")}\n`);
 
+  const failedPresets = [];
+
   for (const preset of presets) {
     const { startIdx, endIdx } = computeQuarterRange(preset);
     console.log(`   [${preset}] ${TIME_LABELS[startIdx]} to ${TIME_LABELS[endIdx]}...`);
 
-    try {
-      const { analysis, startQuarter, endQuarter } = await generateAnalysis(preset);
+    let lastError = null;
+    const MAX_ATTEMPTS = 2;
 
-      const { error } = await supabase
-        .from("cached_analyses")
-        .upsert({
-          date_range: preset,
-          analysis,
-          start_quarter: startQuarter,
-          end_quarter: endQuarter,
-          generated_at: new Date().toISOString(),
-        }, { onConflict: "date_range" });
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        const { analysis, startQuarter, endQuarter } = await generateAnalysis(preset);
 
-      if (error) {
-        console.error(`   [${preset}] UPSERT FAILED: ${error.message}`);
-      } else {
-        console.log(`   [${preset}] Done (${analysis.length} chars)`);
+        const { error } = await supabase
+          .from("cached_analyses")
+          .upsert({
+            date_range: preset,
+            analysis,
+            start_quarter: startQuarter,
+            end_quarter: endQuarter,
+            generated_at: new Date().toISOString(),
+          }, { onConflict: "date_range" });
+
+        if (error) {
+          console.error(`   [${preset}] UPSERT FAILED: ${error.message}`);
+          lastError = new Error(error.message);
+        } else {
+          console.log(`   [${preset}] Done (${analysis.length} chars)`);
+          lastError = null;
+        }
+        break; // success or DB error (no retry for DB issues)
+      } catch (err) {
+        lastError = err;
+        // Only retry on HTTP/network errors (status 500, 429, etc.), not JSON parse failures
+        const isRetryable = err.status >= 500 || err.status === 429 || err.code === "ECONNRESET" || err.code === "ETIMEDOUT";
+        if (isRetryable && attempt < MAX_ATTEMPTS) {
+          console.warn(`   [${preset}] Attempt ${attempt} failed (${err.status || err.code}). Retrying in 10s...`);
+          await new Promise(r => setTimeout(r, 10000));
+        } else {
+          console.error(`   [${preset}] FAILED: ${err.message}`);
+          break;
+        }
       }
-    } catch (err) {
-      console.error(`   [${preset}] FAILED: ${err.message}`);
     }
+
+    if (lastError) {
+      failedPresets.push(preset);
+    }
+  }
+
+  if (failedPresets.length > 0) {
+    console.error(`\nFailed presets: ${failedPresets.join(", ")}`);
+    process.exit(1);
   }
 
   console.log("\nDone!");

--- a/scripts/run-pipeline.mjs
+++ b/scripts/run-pipeline.mjs
@@ -144,6 +144,7 @@ async function diffScores(supabase, beforeSnapshot) {
         previous: prevScore,
         model: after.model,
         verified: after.verified,
+        source: after.source,
       });
     }
   }
@@ -266,6 +267,22 @@ function labName(key) {
 }
 
 /**
+ * Get human-readable source name, fallback to key.
+ */
+function sourceName(key) {
+  const names = {
+    artificialanalysis: "Artificial Analysis",
+    swebench: "SWE-bench",
+    arcprize: "ARC Prize",
+    epoch: "Epoch AI",
+    model_card: "Model Card",
+    model_card_auto: "Model Card (auto)",
+    manual: "Manual",
+  };
+  return names[key] || key || "Unknown";
+}
+
+/**
  * Build the combined GitHub issue report.
  */
 function buildReport({ changes, flagged, rejected, extractResult, ingestResult, labFreshness, runDate }) {
@@ -337,12 +354,12 @@ function buildReport({ changes, flagged, rejected, extractResult, ingestResult, 
   if (changes.length > 0) {
     parts.push("Changes to best scores on the live site this run.");
     parts.push("");
-    parts.push("| Benchmark | Lab | Score | Previous | Model | Status |");
-    parts.push("|-----------|-----|-------|----------|-------|--------|");
+    parts.push("| Benchmark | Lab | Score | Previous | Model | Source | Status |");
+    parts.push("|-----------|-----|-------|----------|-------|--------|--------|");
     for (const c of changes) {
       const prev = c.previous !== null ? c.previous : "—";
       const status = c.verified ? "Verified" : "Unverified";
-      parts.push(`| ${benchmarkName(c.benchmark)} | ${labName(c.lab)} | ${c.score} | ${prev} | ${c.model} | ${status} |`);
+      parts.push(`| ${benchmarkName(c.benchmark)} | ${labName(c.lab)} | ${c.score} | ${prev} | ${c.model} | ${sourceName(c.source)} | ${status} |`);
     }
   } else {
     parts.push("_No changes this run._");

--- a/scripts/update-data.js
+++ b/scripts/update-data.js
@@ -739,30 +739,50 @@ async function main() {
   }
 
   // Write raw observations to benchmark_raw (audit trail — includes all points, even filtered ones)
+  // Hardcoded list: sources owned by this ingestion script. model_card_auto is excluded
+  // because those rows are owned by the extraction pipeline (extract-model-cards.mjs).
+  const INGESTION_SOURCES = ["artificialanalysis", "swebench", "arcprize", "epoch", "model_card", "manual"];
   const allRawPoints = allMerged;
   if (allRawPoints.length > 0) {
-    console.log(`   Writing ${allRawPoints.length} raw observations to benchmark_raw...`);
-    const rawRows = allRawPoints.map(p => ({
-      benchmark: p.benchmark,
-      lab: p.lab,
-      model: p.model,
-      score: Math.round(p.score * 10) / 10,
-      date: p.date.toISOString().split("T")[0],
-      source: p.source,
-      verified: p.verified !== false,
-    }));
+    // Filter out model_card_auto rows (already in DB, managed by extraction pipeline)
+    const rawRows = allRawPoints
+      .filter(p => p.source !== "model_card_auto")
+      .map(p => ({
+        benchmark: p.benchmark,
+        lab: p.lab,
+        model: p.model,
+        score: Math.round(p.score * 10) / 10,
+        date: p.date.toISOString().split("T")[0],
+        source: p.source,
+        verified: p.verified !== false,
+      }));
+
+    console.log(`   Writing ${rawRows.length} raw observations to benchmark_raw...`);
+
+    // Delete existing rows for ingestion-owned sources (scoped delete + insert)
+    const { error: rawDelError } = await supabase
+      .from("benchmark_raw")
+      .delete()
+      .in("source", INGESTION_SOURCES);
+
+    if (rawDelError) {
+      console.error(`   benchmark_raw delete FAILED: ${rawDelError.message}`);
+      process.exit(1);
+    }
+    console.log(`   Deleted existing rows for ingestion sources: ${INGESTION_SOURCES.join(", ")}`);
 
     for (let i = 0; i < rawRows.length; i += BATCH_SIZE) {
       const batch = rawRows.slice(i, i + BATCH_SIZE);
       const { error } = await supabase
         .from("benchmark_raw")
-        .upsert(batch, { onConflict: "benchmark,lab,model,source" });
+        .insert(batch);
 
       if (error) {
-        console.warn(`   benchmark_raw upsert WARN (batch ${Math.floor(i / BATCH_SIZE) + 1}):`, error.message);
+        console.error(`   benchmark_raw insert FAILED (batch ${Math.floor(i / BATCH_SIZE) + 1}): ${error.message}`);
+        process.exit(1);
       }
     }
-    console.log(`   benchmark_raw: upserted ${rawRows.length} rows.`);
+    console.log(`   benchmark_raw: inserted ${rawRows.length} rows.`);
   }
 
   // Automated benchmarks managed by this script. Manual seeds (humaneval) are excluded.


### PR DESCRIPTION
## Summary
Fixes all issues found when reviewing the first scheduled pipeline run (issue #33):

- **Article date filtering**: Old articles (Grok 1 from 2023, etc.) were being scraped because `lastExtractionDate` was calculated but never used. Now skips LLM extraction for articles older than cutoff; fails open on unparseable dates.
- **OpenAI blog index hydration**: `scanBlogIndex()` used shorter wait times than `extractPageContent()`, so OpenAI's Next.js index never rendered. Matched to 6s hydration wait.
- **benchmark_raw duplicates**: Upsert referenced a dropped unique constraint, silently inserting duplicates every run. Switched to scoped delete+insert matching the extraction pipeline pattern.
- **Analysis retry + failure reporting**: Added selective retry for HTTP/network errors (not JSON parse), exit(1) on failure, and a workflow step that comments on the pipeline issue instead of creating a misleading "FAILED" issue.
- **Source column in diff table**: "New Scores on Site" table now shows where each score came from (e.g., "ARC Prize", "Artificial Analysis").

## Test plan
- [x] All 334 tests pass (`npm test`)
- [x] All 5 modified files pass syntax check
- [ ] Verify fixes in next scheduled run (2026-04-02) per verification checklist in project memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)