### PR TITLE
HF API extraction for DeepSeek, Kimi, MiniMax, Zhipu

### DIFF
--- a/lib/extraction.js
+++ b/lib/extraction.js
@@ -381,6 +381,110 @@ function crossCheckScores(scores) {
   });
 }
 
+// ─── Hugging Face Hub helpers ─────────────────────────────────
+
+/**
+ * Filter the raw /api/models?author=... response down to candidate model cards.
+ * Pure function: takes the API JSON and a `now` reference, returns a sorted array.
+ *
+ * Filters:
+ *   - lastModified within `windowMs` of `now` (catches stub READMEs filled in later)
+ *   - pipeline_tag in allowed set (skips TTS, image-feature-extraction, encoders, etc.)
+ *   - id local part does not match the suffix-exclude regex (Base/FP8/AWQ/GPTQ/...)
+ *   - tags do not include `base_model:quantized:` (HF's own derivative-quantization marker)
+ *
+ * NOTE on tag-based quantization filtering: we deliberately do NOT exclude on bare
+ * tags like `fp8`/`gptq`/`awq`. DeepSeek V4 and MiniMax M2.7 are natively trained
+ * in fp8 — those tags appear on the flagship, not just on derivative quants. The
+ * `-FP8`/`-AWQ`/etc. suffix on the repo ID is a more reliable signal for derivative
+ * repos, and `base_model:quantized:` is how HF surfaces actual lineage.
+ *
+ * Sort: newest createdAt first (deterministic given API result is stable).
+ */
+const HF_DEFAULT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const HF_DEFAULT_PIPELINE_TAGS = new Set(["text-generation", "image-text-to-text"]);
+const HF_DEFAULT_SUFFIX_EXCLUDE = /-(Base|FP8|AWQ|GPTQ|Int4|Int8|GGUF)$/i;
+const HF_DEFAULT_DERIVATIVE_TAG_PREFIX = "base_model:quantized:";
+
+function filterHfModels(models, opts = {}) {
+  if (!Array.isArray(models)) return [];
+  const {
+    now = new Date(),
+    windowMs = HF_DEFAULT_WINDOW_MS,
+    allowedPipelineTags = HF_DEFAULT_PIPELINE_TAGS,
+    suffixExclude = HF_DEFAULT_SUFFIX_EXCLUDE,
+    derivativeTagPrefix = HF_DEFAULT_DERIVATIVE_TAG_PREFIX,
+    limit = 20,
+  } = opts;
+
+  const cutoffMs = now.getTime() - windowMs;
+
+  const kept = [];
+  for (const m of models) {
+    if (!m || typeof m !== "object" || !m.id) continue;
+    if (!m.lastModified || !m.createdAt) continue;
+    const lastModMs = new Date(m.lastModified).getTime();
+    if (Number.isNaN(lastModMs) || lastModMs < cutoffMs) continue;
+    if (!allowedPipelineTags.has(m.pipeline_tag)) continue;
+    const localName = String(m.id).split("/")[1] || String(m.id);
+    if (suffixExclude.test(localName)) continue;
+    const tags = Array.isArray(m.tags) ? m.tags.map(t => String(t).toLowerCase()) : [];
+    if (tags.some(t => t.startsWith(derivativeTagPrefix))) continue;
+    kept.push(m);
+  }
+
+  // Sort newest createdAt first for deterministic ordering across runs.
+  kept.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  return kept.slice(0, limit);
+}
+
+/**
+ * Parse a HF README markdown blob for image references (markdown + HTML img tags).
+ * Resolves relative paths to HF's resolve URL pattern. Skips .svg, .gif, .webp.
+ *
+ * @param {string} markdown
+ * @param {string} hfModelId — e.g., "deepseek-ai/DeepSeek-V4-Pro"
+ * @param {string} branch — sha or branch name (e.g., "main")
+ * @returns {string[]} absolute image URLs, deduplicated
+ */
+function parseHfReadmeImages(markdown, hfModelId, branch) {
+  if (!markdown || typeof markdown !== "string") return [];
+  if (!hfModelId || !branch) return [];
+
+  const seen = new Set();
+  const out = [];
+
+  const tryAdd = (raw) => {
+    if (!raw || typeof raw !== "string") return;
+    const trimmed = raw.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+
+    let abs;
+    if (/^https?:\/\//i.test(trimmed)) {
+      abs = trimmed;
+    } else if (trimmed.startsWith("data:") || trimmed.startsWith("#")) {
+      return;
+    } else {
+      const cleaned = trimmed.replace(/^\.\//, "").replace(/^\//, "");
+      abs = `https://huggingface.co/${hfModelId}/resolve/${branch}/${cleaned}`;
+    }
+    if (/\.(svg|gif|webp)(\?|#|$)/i.test(abs)) return;
+    out.push(abs);
+  };
+
+  // Markdown image syntax: ![alt](url) or ![alt](url "title")
+  const mdImg = /!\[[^\]]*\]\(([^)\s]+)/g;
+  let m;
+  while ((m = mdImg.exec(markdown)) !== null) tryAdd(m[1]);
+
+  // HTML <img src="..."> — common inside <p align="center"> wrappers in HF READMEs
+  const htmlImg = /<img\b[^>]*\bsrc\s*=\s*["']([^"']+)["']/gi;
+  while ((m = htmlImg.exec(markdown)) !== null) tryAdd(m[1]);
+
+  return out;
+}
+
 // ─── JSON schema for structured outputs ───────────────────────
 
 /**
@@ -432,6 +536,8 @@ module.exports = {
   triageScore,
   crossCheckScores,
   normalizeVariant,
+  filterHfModels,
+  parseHfReadmeImages,
   BENCHMARK_ALIASES,
   SCORES_SCHEMA,
 };

--- a/lib/lab-sources.js
+++ b/lib/lab-sources.js
@@ -1,6 +1,17 @@
 // lib/lab-sources.js
-// Blog index URLs and metadata per lab for automated model card extraction.
+// Discovery configuration per lab for automated model card extraction.
 // Used by scripts/extract-model-cards.mjs.
+//
+// Discovery surfaces:
+//   feedUrl                       — RSS/Atom feed (no browser, no anti-bot)
+//   scanMethod: "huggingfaceApi"  — HF Hub API (no browser; expects hfAuthor)
+//   scanMethod: "qwenCards"       — qwen.ai/research card scanner (Playwright)
+//   indexUrl + articlePathPattern — generic blog index DOM scan (Playwright)
+//
+// Browser backend dispatch:
+//   useBrowserbase: true → cloud browser (Browserbase) for anti-bot heavy sites
+//   default              → local headless Playwright
+// HF API and RSS sources skip BrowserPool entirely.
 
 const LAB_SOURCES = [
   {
@@ -36,13 +47,40 @@ const LAB_SOURCES = [
     articlePathPattern: /\/news\/.+/,
     minExpectedArticles: 2,
   },
+  // Chinese Leaders composite. Four labs published to HF (DeepSeek, Kimi, MiniMax, Zhipu)
+  // share a single HF API path (no browser, no anti-bot). Qwen flagship cards live on
+  // qwen.ai/research instead, so it keeps the dedicated card scanner.
   {
     lab: "chinese",
     name: "DeepSeek",
     slug: "deepseek",
-    indexUrl: "https://huggingface.co/deepseek-ai",
-    articlePathPattern: /\/deepseek-ai\/DeepSeek-/,
-    minExpectedArticles: 2,
+    scanMethod: "huggingfaceApi",
+    hfAuthor: "deepseek-ai",
+    minExpectedArticles: 1,
+  },
+  {
+    lab: "chinese",
+    name: "Kimi",
+    slug: "kimi",
+    scanMethod: "huggingfaceApi",
+    hfAuthor: "moonshotai",
+    minExpectedArticles: 1,
+  },
+  {
+    lab: "chinese",
+    name: "MiniMax",
+    slug: "minimax",
+    scanMethod: "huggingfaceApi",
+    hfAuthor: "MiniMaxAI",
+    minExpectedArticles: 1,
+  },
+  {
+    lab: "chinese",
+    name: "Zhipu",
+    slug: "zhipu",
+    scanMethod: "huggingfaceApi",
+    hfAuthor: "zai-org",
+    minExpectedArticles: 1,
   },
   {
     lab: "chinese",

--- a/lib/llm-extract.js
+++ b/lib/llm-extract.js
@@ -146,6 +146,192 @@ ${textContent}`,
   return parseStructuredResponse(response);
 }
 
+// ─── HF model card markdown extraction ───────────────────────
+// HF READMEs differ from blog posts:
+//   1. They almost always include comparison tables with multiple model columns.
+//      The standard text prompt's "extract scores for X" instruction is not
+//      enough — the LLM has no spatial cues in markdown to identify which
+//      column is the target model. Forcing it to echo back the column header
+//      lets us add a programmatic guard against off-by-one column errors.
+//   2. Same-family-different-version is the most common hallucination pattern
+//      (e.g. a GLM-4.7 README referencing GLM-4.6 in a comparison row).
+//      Token-overlap heuristics cannot catch this — only the prompt can.
+
+const HF_EXTRACT_TOOL = {
+  name: "extract_hf_scores",
+  description: "Record benchmark scores from a Hugging Face model card README.",
+  input_schema: {
+    type: "object",
+    properties: {
+      scores: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            benchmark: { type: "string", description: "Specific benchmark name as written (e.g., 'GPQA Diamond', 'SWE-bench Verified', 'HLE'). Do NOT include qualifiers." },
+            score: { type: "number", description: "Exact numeric score, no % sign." },
+            model_variant: { type: "string", description: "Evaluation qualifier if any (e.g., 'with tools', 'thinking', 'OpenHands'). Omit if none." },
+            column_header: { type: "string", description: "If the score came from a comparison table, the exact text of the column header it was in. Omit if the score was in prose or in a single-model table." },
+            row_label: { type: "string", description: "If the score came from a table, the row label (usually the benchmark name). Omit if prose." },
+            table_caption: { type: "string", description: "If the score came from a table, any caption or heading directly above it. Omit if none." },
+            notes: { type: "string", description: "Where in the document the score appeared (e.g., 'main eval table', 'agentic capabilities section'). Optional." },
+          },
+          required: ["benchmark", "score"],
+        },
+      },
+    },
+    required: ["scores"],
+  },
+};
+
+/**
+ * Extract benchmark scores from HF model card README markdown.
+ * Uses a HF-specific prompt that forces the LLM to identify the model column
+ * in comparison tables, plus explicit handling of same-family-different-version
+ * cases. Caller should run extractColumnHeaderGuard() on the result.
+ *
+ * @param {import("@anthropic-ai/sdk").default} anthropic
+ * @param {Object} opts
+ * @param {string} opts.markdown - Raw README markdown
+ * @param {string} opts.modelName - Target model (e.g., "MiniMax-M2.7")
+ * @returns {Promise<Array>} scores
+ */
+async function extractScoresFromHfMarkdown(anthropic, { markdown, modelName }) {
+  if (!markdown || markdown.trim().length < 50) return [];
+
+  // Cap markdown size to control token spend on huge READMEs.
+  // 60kB ≈ ~15k tokens, comfortable for sonnet's 4k output budget.
+  const CAP = 60_000;
+  const text = markdown.length > CAP
+    ? markdown.substring(0, CAP) + "\n\n[... README truncated for length ...]"
+    : markdown;
+
+  // 16K output budget: DeepSeek V4 READMEs emit ~80 scores across 3 eval tables,
+  // each carrying ~200 tokens of structured fields. 4K silently truncates the tool
+  // call mid-stream and the SDK returns the empty input — ie. zero scores extracted.
+  const response = await anthropic.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 16384,
+    temperature: 0,
+    system: "You extract benchmark scores from Hugging Face model card READMEs (markdown).",
+    tools: [HF_EXTRACT_TOOL],
+    tool_choice: { type: "tool", name: "extract_hf_scores" },
+    messages: [{
+      role: "user",
+      content: `Extract every benchmark score that applies to "${modelName}" from this Hugging Face model card README. The README is FOR "${modelName}", so any score described as the model's own performance is in scope.
+
+The "${modelName}" column in comparison tables may appear under any of these forms — extract scores under all of them:
+- The exact name
+- An abbreviation: "DS-V4-Pro" for "DeepSeek-V4-Pro", "K2.6" for "Kimi-K2.6", "M2.7" for "MiniMax-M2.7", "GLM-5.1" for "GLM-5.1"
+- With a reasoning-mode suffix attached: "${modelName} Max", "${modelName} High", "${modelName} Non-Think", "${modelName} Thinking", "DS-V4-Pro Max", "K2.6 Thinking", etc. Put the mode in model_variant. If the README explicitly says "Pro-Max is the maximum reasoning mode of Pro", treat "Pro-Max" columns as the target model with model_variant="Max".
+- With "with tools" / "without tools" / "with python" qualifiers — same idea, put the qualifier in model_variant.
+
+DO NOT extract from columns for:
+- OTHER labs (Opus, GPT, Gemini, Claude, etc.).
+- SIBLING MODELS from the same lab — e.g. if target is "DeepSeek-V4-Pro", skip "V4-Flash"; if target is "GLM-5.1", skip "GLM-4.6"; if target is "Kimi-K2.6", skip "Kimi-K2.5".
+- BASE / PRETRAINING CHECKPOINTS — any column ending in "-Base" or labeled "Base" is a pre-instruction-tuning checkpoint, NOT the target model. Skip these. Example: if target is "DeepSeek-V4-Pro", skip "DeepSeek-V4-Pro-Base" columns. The base model has its own benchmarks measured under different conditions and is not comparable to the instructed model.
+
+If you're unsure whether a column refers to the target (e.g. "DS-V4-Pro Max" — abbreviation + reasoning mode), prefer to include it (with column_header populated) — the downstream guard will drop misidentified columns.
+
+For each score in a table, populate column_header with the exact column header text you read. For scores in prose (e.g. "achieved 56.22% on SWE-Pro"), omit column_header.
+
+OTHER RULES:
+- Report exact numbers (no rounding, no % sign).
+- Extract the benchmark name as written ("GPQA Diamond", "SWE-bench Verified"). Do NOT include capability descriptors ("Agentic Reasoning", "Coding").
+- If a row presents multiple variants for ${modelName} ("Non-Think" / "Thinking" / "Max" / "with tools"), extract each as a separate score with the variant in model_variant.
+- If the evaluation uses a third-party scaffold or harness ("OpenHands", "WebExplorer", "Trae", "Aider"), put that in model_variant.
+- If a cell is "N/A", "—", "-", "TBD", or empty, do NOT extract it.
+- DO NOT extract scores from quotes or testimonials.
+- Extract from prose with marketing-style language ("achieved X on Benchmark Y") just like from tables.
+
+OUTPUT for each score:
+- benchmark, score (required)
+- model_variant, column_header, row_label, table_caption, notes (optional but include when applicable)
+
+README MARKDOWN:
+${text}`,
+    }],
+  });
+
+  const toolBlock = response.content.find(b => b.type === "tool_use" && b.name === "extract_hf_scores");
+  if (!toolBlock) return [];
+  return (toolBlock.input.scores || []).filter(s => s.score != null && s.benchmark);
+}
+
+/**
+ * Programmatic backstop for the column-header check enforced in the prompt.
+ * Drops scores where column_header is present but doesn't fuzzy-match modelName.
+ * Scores without column_header (prose extractions) pass through unchanged.
+ *
+ * Fuzzy match: case-insensitive token comparison after stripping known suffix
+ * variants (-Base, -Pro, -Flash, -Max, -Instruct, -Mini, -Lite, -Air) and
+ * non-alphanumerics. A column header passes if it shares at least one
+ * 3+-char token with the modelName, after suffix stripping.
+ *
+ * Note: the same-family-different-version case (e.g., GLM-4.6 vs GLM-4.7) is
+ * the prompt's responsibility — token overlap cannot distinguish them.
+ *
+ * @param {Array} scores - Output from extractScoresFromHfMarkdown
+ * @param {string} modelName - Target model
+ * @returns {{ kept: Array, dropped: Array }}
+ */
+function columnHeaderGuard(scores, modelName) {
+  // Tokens: split on separators, drop tier-suffix words, drop pure-numeric
+  // (so "M2.7" → ["m2"], "Kimi-K2.6" → ["kimi", "k2"]). Pure-numeric tokens
+  // are dropped because version digits alone can collide spuriously across
+  // unrelated models. We keep tokens of length 2+ that contain at least one
+  // letter — this catches "m2", "k2", "v4", "glm" and other short version IDs.
+  const tokenize = (s) => {
+    if (!s || typeof s !== "string") return [];
+    return s.toLowerCase()
+      .replace(/[\-_/.()]/g, " ")
+      .replace(/\b(base|pro|flash|max|instruct|mini|lite|air|preview|exp)\b/g, " ")
+      .split(/\s+/)
+      .filter(t => t.length >= 2 && /[a-z]/.test(t));
+  };
+
+  const targetTokens = new Set(tokenize(modelName));
+  // Base-checkpoint columns: drop unless the target itself is a Base model.
+  // The prompt instructs the LLM to skip these but it isn't 100% reliable on
+  // multi-table READMEs (e.g. DeepSeek V4-Flash README where the Base column
+  // sits alongside the instructed model's mode columns).
+  const targetIsBase = /-base\b/i.test(modelName || "");
+  const baseColumnRegex = /(^|\b|[\-_\s])base($|\b|[\-_\s])/i;
+
+  if (targetTokens.size === 0) return { kept: scores, dropped: [] };
+
+  const kept = [];
+  const dropped = [];
+
+  for (const s of scores) {
+    if (!s.column_header) {
+      kept.push(s);
+      continue;
+    }
+
+    if (!targetIsBase && baseColumnRegex.test(s.column_header)) {
+      dropped.push({
+        ...s,
+        _dropReason: `column_header "${s.column_header}" is a -Base checkpoint, target "${modelName}" is the instructed model`,
+      });
+      continue;
+    }
+
+    const headerTokens = tokenize(s.column_header);
+    const hasOverlap = headerTokens.some(t => targetTokens.has(t));
+    if (hasOverlap) {
+      kept.push(s);
+    } else {
+      dropped.push({
+        ...s,
+        _dropReason: `column_header "${s.column_header}" shares no token with modelName "${modelName}"`,
+      });
+    }
+  }
+
+  return { kept, dropped };
+}
+
 // ─── Variant review ──────────────────────────────────────────
 
 const VARIANT_REVIEW_TOOL = {
@@ -297,6 +483,8 @@ ${articles.map((a, i) => `${i}. "${a.title}" (${a.url})`).join("\n")}`;
 module.exports = {
   extractScoresFromImage,
   extractScoresFromText,
+  extractScoresFromHfMarkdown,
+  columnHeaderGuard,
   classifyArticles,
   reviewVariants,
 };

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -132,6 +132,15 @@ const HARNESS_KEYWORDS = [
   "scaffold(ing)?",
   "browsing(\\s+enabled)?",
   "internet\\s+access",
+  // Named third-party scaffolds/CLIs that change evaluation conditions.
+  // Common in HF model cards from Chinese labs (DeepSeek, Kimi, MiniMax, Zhipu).
+  "openhands",
+  "webexplorer",
+  "claude[\\s-]code(\\s+cli)?",
+  "trae",
+  "aider",
+  "cline",
+  "roo[\\s-]code",
 ];
 const HARNESS_PATTERN = new RegExp(`\\b(?:${HARNESS_KEYWORDS.join("|")})\\b`, "i");
 

--- a/scripts/extract-model-cards.mjs
+++ b/scripts/extract-model-cards.mjs
@@ -47,10 +47,11 @@ const { BENCHMARK_META } = require("../lib/config.js");
 const {
   extractRawImageUrl, filterContentImages, buildTextBlock,
   deduplicateScores, parsePublishDate,
+  filterHfModels, parseHfReadmeImages,
 } = require("../lib/extraction.js");
 const {
-  extractScoresFromImage, extractScoresFromText, classifyArticles,
-  reviewVariants,
+  extractScoresFromImage, extractScoresFromText, extractScoresFromHfMarkdown,
+  columnHeaderGuard, classifyArticles, reviewVariants,
 } = require("../lib/llm-extract.js");
 
 // ESM imports
@@ -121,6 +122,7 @@ const MARKER_DIR = os.tmpdir();
 const MARKER_STARTED = path.join(MARKER_DIR, "ai-race-extraction-started.json");
 const MARKER_COMPLETE = path.join(MARKER_DIR, "ai-race-extraction-complete.json");
 const MARKER_BB_SKIP = path.join(MARKER_DIR, "ai-race-browserbase-skip.json");
+const MARKER_HF_DISCOVERY_FAIL = path.join(MARKER_DIR, "ai-race-hf-discovery-fail.json");
 
 function writeMarker(filePath, payload) {
   try {
@@ -187,6 +189,199 @@ async function discoverViaFeed(source) {
     console.warn(`   WARNING: Found ${filtered.length} articles, expected at least ${source.minExpectedArticles}.`);
   }
   return capped;
+}
+
+// ─── Hugging Face API discovery ──────────────────────────────
+
+const HF_USER_AGENT = "ai-race-pipeline/1.0 (+https://ai-race.vercel.app)";
+const HF_DISCOVERY_LIMIT = 50;        // upper bound on the API response
+const HF_DISCOVERY_MAX_RESULTS = 20;  // how many candidates we'll process per lab
+
+/**
+ * Discover candidate model articles from a Hugging Face org via the Hub API.
+ * Pure HTTP, no browser. Throws on non-200 (caller logs + records via marker).
+ *
+ * Filter logic lives in lib/extraction.js#filterHfModels for testability.
+ */
+async function discoverViaHfApi(source) {
+  const apiUrl = `https://huggingface.co/api/models?author=${encodeURIComponent(source.hfAuthor)}&sort=lastModified&direction=-1&limit=${HF_DISCOVERY_LIMIT}`;
+  console.log(`   Fetching HF API ${source.name} (${source.hfAuthor})...`);
+
+  const resp = await fetch(apiUrl, {
+    headers: { "User-Agent": HF_USER_AGENT },
+    signal: AbortSignal.timeout(30000),
+  });
+  if (!resp.ok) {
+    throw new Error(`HF API ${resp.status} ${resp.statusText} for ${source.hfAuthor}`);
+  }
+
+  const models = await resp.json();
+  if (!Array.isArray(models)) {
+    throw new Error(`HF API for ${source.hfAuthor} returned non-array (${typeof models})`);
+  }
+
+  const filtered = filterHfModels(models, { limit: HF_DISCOVERY_MAX_RESULTS });
+
+  const articles = filtered.map(m => ({
+    title: m.id,
+    url: `https://huggingface.co/${m.id}`,
+    modelName: String(m.id).split("/")[1] || String(m.id),
+    hfModelId: m.id,
+    lastModified: m.lastModified,
+    createdAt: m.createdAt,
+  }));
+
+  console.log(`   ${source.name}: ${models.length} total, ${articles.length} after filtering`);
+  if (source.minExpectedArticles && articles.length < source.minExpectedArticles) {
+    console.warn(`   WARNING: ${source.name} returned ${articles.length} candidates, expected at least ${source.minExpectedArticles}.`);
+  }
+
+  return articles;
+}
+
+// ─── Hugging Face README extraction ──────────────────────────
+
+/**
+ * Fetch + extract benchmark scores from a HF model card README.
+ * Pure HTTP, no browser. Returns { scores, publishDate } — same shape as extractFromArticle.
+ *
+ * publishDate is the HF createdAt (model release date). lastModified is used
+ * upstream by the re-extraction trigger, not by score dating.
+ */
+async function extractFromHfReadme(anthropic, article) {
+  console.log(`\n   Extracting: "${article.modelName}" from ${article.url}`);
+  const publishDate = article.createdAt ? new Date(article.createdAt) : null;
+  if (publishDate) {
+    console.log(`     Publish date (HF createdAt): ${publishDate.toISOString().split("T")[0]}`);
+  }
+
+  // Resolve to a sha so the URL is stable across the run even if branch updates.
+  let revision = "main";
+  try {
+    const metaResp = await fetch(`https://huggingface.co/api/models/${article.hfModelId}`, {
+      headers: { "User-Agent": HF_USER_AGENT },
+      signal: AbortSignal.timeout(20000),
+    });
+    if (metaResp.ok) {
+      const meta = await metaResp.json();
+      if (meta && typeof meta.sha === "string" && meta.sha.length > 0) {
+        revision = meta.sha;
+      }
+    } else {
+      console.warn(`     HF metadata fetch returned ${metaResp.status} (proceeding with main)`);
+    }
+  } catch (err) {
+    console.warn(`     HF metadata fetch error: ${err.message.substring(0, 100)} (proceeding with main)`);
+  }
+
+  // Fetch README. Tolerate 401/403 (gated) / 404 (no README) by returning empty + loud log.
+  const readmeUrl = `https://huggingface.co/${article.hfModelId}/raw/${revision}/README.md`;
+  let markdown;
+  try {
+    const resp = await fetch(readmeUrl, {
+      headers: { "User-Agent": HF_USER_AGENT },
+      signal: AbortSignal.timeout(30000),
+    });
+    if (resp.status === 401 || resp.status === 403) {
+      console.warn(`     [HF gated] README requires auth (${resp.status}): ${article.hfModelId}`);
+      return { scores: [], publishDate };
+    }
+    if (resp.status === 404) {
+      console.warn(`     [HF missing] No README: ${article.hfModelId}`);
+      return { scores: [], publishDate };
+    }
+    if (!resp.ok) {
+      console.warn(`     README fetch failed: ${resp.status} ${resp.statusText}`);
+      return { scores: [], publishDate };
+    }
+    markdown = await resp.text();
+  } catch (err) {
+    console.warn(`     README fetch error: ${err.message.substring(0, 100)}`);
+    return { scores: [], publishDate };
+  }
+
+  if (!markdown || markdown.trim().length < 100) {
+    console.warn(`     README very short (${markdown.length} chars), skipping LLM`);
+    return { scores: [], publishDate };
+  }
+
+  // Image references
+  const imageUrls = parseHfReadmeImages(markdown, article.hfModelId, revision);
+  const HF_IMAGE_CAP = 5;
+  const cappedUrls = imageUrls.slice(0, HF_IMAGE_CAP);
+  console.log(`     Found ${imageUrls.length} image refs (using top ${cappedUrls.length})`);
+
+  // Download in parallel (existing helper, pure fetch)
+  const downloadResults = await Promise.all(
+    cappedUrls.map(async (imgUrl) => {
+      const result = await downloadImage(imgUrl);
+      if (result) return { url: imgUrl, ...result };
+      return null;
+    })
+  );
+  const downloadedImages = downloadResults.filter(Boolean);
+  console.log(`     Downloaded ${downloadedImages.length}/${cappedUrls.length} images`);
+
+  // Vision in parallel (cap concurrency)
+  const MAX_CONCURRENT_VISION = 5;
+  const visionScores = [];
+  for (let i = 0; i < downloadedImages.length; i += MAX_CONCURRENT_VISION) {
+    const batch = downloadedImages.slice(i, i + MAX_CONCURRENT_VISION);
+    const batchResults = await Promise.all(
+      batch.map(img =>
+        extractScoresFromImage(anthropic, {
+          base64Data: img.base64Data,
+          mediaType: img.mediaType,
+          modelName: article.modelName,
+        }).catch(err => {
+          console.warn(`     Vision error on ${img.url.substring(0, 80)}: ${err.message.substring(0, 100)}`);
+          return [];
+        })
+      )
+    );
+    visionScores.push(...batchResults.flat());
+  }
+
+  // HF-specific markdown extractor + column-header guard
+  let textScores = [];
+  try {
+    const raw = await extractScoresFromHfMarkdown(anthropic, {
+      markdown,
+      modelName: article.modelName,
+    });
+    const guarded = columnHeaderGuard(raw, article.modelName);
+    textScores = guarded.kept;
+    if (guarded.dropped.length > 0) {
+      console.log(`     Column-header guard dropped ${guarded.dropped.length} score(s):`);
+      for (const d of guarded.dropped) {
+        console.log(`       — ${d.benchmark}: ${d.score} from "${d.column_header}"`);
+      }
+    }
+  } catch (err) {
+    console.warn(`     HF markdown extraction error: ${err.message.substring(0, 100)}`);
+  }
+
+  console.log(`     Vision: ${visionScores.length} scores from ${downloadedImages.length} images`);
+  console.log(`     Text: ${textScores.length} scores`);
+
+  if (visionScores.length > 0) {
+    console.log(`\n     --- Raw vision scores ---`);
+    for (const s of visionScores) {
+      console.log(`     ${s.benchmark}: ${s.score}${s.model_variant ? ` [variant: ${s.model_variant}]` : ""}`);
+    }
+  }
+  if (textScores.length > 0) {
+    console.log(`\n     --- Raw text scores ---`);
+    for (const s of textScores) {
+      console.log(`     ${s.benchmark}: ${s.score}${s.model_variant ? ` [variant: ${s.model_variant}]` : ""}${s.column_header ? ` [col: ${s.column_header}]` : ""}`);
+    }
+  }
+  console.log("");
+
+  const deduped = deduplicateScores(visionScores, textScores);
+  console.log(`     ${deduped.length} unique scores after dedup`);
+
+  return { scores: deduped, publishDate };
 }
 
 // ─── Blog index scanning ─────────────────────────────────────
@@ -608,6 +803,7 @@ async function main() {
   unlinkMarker(MARKER_STARTED);
   unlinkMarker(MARKER_COMPLETE);
   unlinkMarker(MARKER_BB_SKIP);
+  unlinkMarker(MARKER_HF_DISCOVERY_FAIL);
   writeMarker(MARKER_STARTED, { pid: process.pid, dryRun: DRY_RUN });
 
   const supabase = DRY_RUN ? null : createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
@@ -619,9 +815,12 @@ async function main() {
   const browserbaseSkipped = []; // { url, reason } — populated if Browserbase is unavailable
   let browserbaseUnavailable = false;
 
-  // Get last extraction date + processed URLs from DB
+  // Get last extraction date + processed URLs from DB.
+  // processedUrls is a Map<url, mostRecentExtractedAt> so HF sources can re-extract
+  // when their README's lastModified moves past the prior extracted_at (post-launch
+  // README edits are common — labs push a stub then fill in eval tables).
   let lastExtractionDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-  const processedUrls = new Set();
+  const processedUrls = new Map();
 
   if (supabase) {
     const { data: lastData } = await supabase
@@ -637,13 +836,28 @@ async function main() {
     if (!FORCE) {
       const { data: urlData } = await supabase
         .from("benchmark_raw")
-        .select("source_url")
+        .select("source_url, extracted_at")
         .eq("source", "model_card_auto")
         .not("source_url", "is", null);
       if (urlData) {
-        for (const row of urlData) processedUrls.add(row.source_url);
+        for (const row of urlData) {
+          const prev = processedUrls.get(row.source_url);
+          if (!prev || new Date(row.extracted_at) > new Date(prev)) {
+            processedUrls.set(row.source_url, row.extracted_at);
+          }
+        }
       }
     }
+  }
+
+  // Returns true if this URL has been processed AND there is no signal that the
+  // upstream content has been updated since (HF only — non-HF articles have no
+  // lastModified, so they always skip when processedUrls.has(url) is true).
+  function shouldSkipAlreadyProcessed(article) {
+    if (!processedUrls.has(article.url)) return false;
+    if (!article.lastModified) return true;
+    const prevAt = processedUrls.get(article.url);
+    return new Date(article.lastModified) <= new Date(prevAt);
   }
 
   console.log(`Last extraction: ${lastExtractionDate.toISOString().split("T")[0]}`);
@@ -668,6 +882,7 @@ async function main() {
 
   const newArticles = [];
   const allExtracted = [];
+  const hfDiscoveryFailures = []; // { source, reason } — surfaces in marker file
 
   // ─── Step 1: Discover articles ─────────────────────────────
 
@@ -690,9 +905,15 @@ async function main() {
       ? LAB_SOURCES.filter(s => s.lab === LAB_FILTER || s.name.toLowerCase() === LAB_FILTER)
       : LAB_SOURCES;
 
-    // Split sources into feed-based (no browser needed) and browser-based
+    // Split sources by discovery method:
+    //   feedSources    — RSS (no browser)
+    //   hfApiSources   — HF Hub API (no browser)
+    //   browserSources — DOM scanning (Playwright/Browserbase)
     const feedSources = sources.filter(s => s.feedUrl);
-    const browserSources = sources.filter(s => !s.feedUrl);
+    const hfApiSources = sources.filter(s => s.scanMethod === "huggingfaceApi");
+    const browserSources = sources.filter(s =>
+      !s.feedUrl && s.scanMethod !== "huggingfaceApi"
+    );
 
     // Discover from feeds first (no browser, avoids triggering anti-bot)
     for (const source of feedSources) {
@@ -707,7 +928,7 @@ async function main() {
           const article = articles[cls.index];
           if (!article) continue;
 
-          if (processedUrls.has(article.url)) {
+          if (shouldSkipAlreadyProcessed(article)) {
             console.log(`   Skipping (already processed): ${article.title}`);
             continue;
           }
@@ -722,6 +943,42 @@ async function main() {
         }
       } catch (err) {
         console.warn(`   Error fetching feed for ${source.name}: ${err.message.substring(0, 150)}`);
+      }
+    }
+
+    // Discover from HF API sources (no browser, no LLM classification — discovery
+    // already filters by createdAt + lastModified + pipeline_tag).
+    for (const source of hfApiSources) {
+      try {
+        const articles = await discoverViaHfApi(source);
+        for (const article of articles) {
+          if (shouldSkipAlreadyProcessed(article)) {
+            console.log(`   Skipping (already processed, README unchanged): ${article.modelName}`);
+            continue;
+          }
+
+          // Re-extraction of an HF article whose README changed: surface explicitly.
+          if (processedUrls.has(article.url)) {
+            console.log(`   RE-EXTRACT (README updated): ${article.modelName}`);
+          } else {
+            console.log(`   NEW: ${article.modelName}`);
+          }
+
+          newArticles.push({
+            source,
+            title: article.title,
+            url: article.url,
+            modelName: article.modelName,
+            hfModelId: article.hfModelId,
+            lastModified: article.lastModified,
+            createdAt: article.createdAt,
+          });
+        }
+      } catch (err) {
+        const reason = err.message.substring(0, 200);
+        console.error(`   HF API discovery failed for ${source.name}: ${reason}`);
+        hfDiscoveryFailures.push({ source: source.name, hfAuthor: source.hfAuthor, reason });
+        // Continue — other sources should still process. Surface via marker file.
       }
     }
 
@@ -773,7 +1030,7 @@ async function main() {
             const article = articles[cls.index];
             if (!article) continue;
 
-            if (processedUrls.has(article.url)) {
+            if (shouldSkipAlreadyProcessed(article)) {
               console.log(`   Skipping (already processed): ${article.title}`);
               continue;
             }
@@ -800,24 +1057,46 @@ async function main() {
   if (newArticles.length === 0) {
     console.log("No new articles to process. Done.");
     await pool.closeAll();
+    if (hfDiscoveryFailures.length > 0) {
+      writeMarker(MARKER_HF_DISCOVERY_FAIL, {
+        reason: "HF API discovery failed for one or more sources",
+        failures: hfDiscoveryFailures,
+      });
+    }
     writeMarker(MARKER_COMPLETE, {
       articlesProcessed: 0,
       scoresExtracted: 0,
       browserbaseSkipped: 0,
       browserbaseUnavailable,
+      hfDiscoveryFailures: hfDiscoveryFailures.length,
     });
     return;
   }
 
   // ─── Step 2: Extract scores from articles ──────────────────
-  // Per-article dispatch via BrowserPool: sources with `useBrowserbase: true`
-  // (currently OpenAI) get the cloud browser; everything else gets local headless.
-  // Browserbase availability errors are isolated per article — other labs ingest normally.
+  // Per-article dispatch:
+  //   HF API sources    → extractFromHfReadme (no browser, pure HTTP)
+  //   useBrowserbase    → cloud browser (currently OpenAI only)
+  //   default           → local headless Playwright
+  // Browser failures (Browserbase outage, HF API errors) are isolated per article —
+  // other labs ingest normally.
 
   console.log("Step 2: Extracting scores from articles...\n");
 
   try {
     for (const article of newArticles) {
+      // HF API path: no browser at all. Pure HTTP fetch + LLM.
+      if (article.source.scanMethod === "huggingfaceApi") {
+        try {
+          const { scores, publishDate } = await extractFromHfReadme(anthropic, article);
+          allExtracted.push({ article, scores, publishDate });
+        } catch (err) {
+          console.error(`   FAILED: ${article.title}: ${err.message.substring(0, 200)}`);
+          allExtracted.push({ article, scores: [], publishDate: null });
+        }
+        continue;
+      }
+
       const kind = browserKindFor(article.source);
 
       // Acquire browser of the right kind. Browserbase failure → skip + mark.
@@ -880,6 +1159,14 @@ async function main() {
       skippedUrls: browserbaseSkipped,
     });
     console.warn(`   ${browserbaseSkipped.length} article(s) skipped due to Browserbase unavailability — see ${MARKER_BB_SKIP}`);
+  }
+
+  if (hfDiscoveryFailures.length > 0) {
+    writeMarker(MARKER_HF_DISCOVERY_FAIL, {
+      reason: "HF API discovery failed for one or more sources",
+      failures: hfDiscoveryFailures,
+    });
+    console.warn(`   ${hfDiscoveryFailures.length} HF source(s) failed discovery — see ${MARKER_HF_DISCOVERY_FAIL}`);
   }
 
   // Log date filtering summary
@@ -1223,6 +1510,7 @@ async function main() {
     scoresExtracted: rawRows.length,
     browserbaseSkipped: browserbaseSkipped.length,
     browserbaseUnavailable,
+    hfDiscoveryFailures: hfDiscoveryFailures.length,
   });
 }
 

--- a/scripts/extract-model-cards.mjs
+++ b/scripts/extract-model-cards.mjs
@@ -197,6 +197,44 @@ const HF_USER_AGENT = "ai-race-pipeline/1.0 (+https://ai-race.vercel.app)";
 const HF_DISCOVERY_LIMIT = 50;        // upper bound on the API response
 const HF_DISCOVERY_MAX_RESULTS = 20;  // how many candidates we'll process per lab
 
+// Retry transient HF errors. Weekly cadence + single-fetch failure mode means
+// one 503 would cost a lab's discovery for the week without retries.
+async function fetchWithRetry(url, opts = {}, attempts = 3) {
+  let lastErr;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const resp = await fetch(url, opts);
+      // 5xx or 429 → retry with backoff; 4xx → caller decides
+      if (resp.status >= 500 || resp.status === 429) {
+        lastErr = new Error(`HF transient ${resp.status} ${resp.statusText} for ${url}`);
+      } else {
+        return resp;
+      }
+    } catch (err) {
+      lastErr = err;
+    }
+    if (i < attempts - 1) {
+      const backoffMs = 500 * Math.pow(2, i); // 500, 1000, 2000
+      await new Promise(r => setTimeout(r, backoffMs));
+    }
+  }
+  throw lastErr;
+}
+
+// Strip HF-only prompt-output fields before scores leave the extractor.
+// `column_header`, `row_label`, `table_caption` are scaffolding for the
+// extraction prompt and the column-header guard — downstream consumers
+// (deduplicateScores, reviewVariants, triage, the row builder) read `notes`
+// with different semantics, so HF-prompt prose like "main eval table" /
+// "marketing section" must be removed to avoid colliding with reviewVariants'
+// "main benchmark table" vs "footnote" heuristic.
+function stripHfPromptScaffolding(scores) {
+  return scores.map(s => {
+    const { column_header, row_label, table_caption, notes, ...rest } = s;
+    return rest;
+  });
+}
+
 /**
  * Discover candidate model articles from a Hugging Face org via the Hub API.
  * Pure HTTP, no browser. Throws on non-200 (caller logs + records via marker).
@@ -207,7 +245,7 @@ async function discoverViaHfApi(source) {
   const apiUrl = `https://huggingface.co/api/models?author=${encodeURIComponent(source.hfAuthor)}&sort=lastModified&direction=-1&limit=${HF_DISCOVERY_LIMIT}`;
   console.log(`   Fetching HF API ${source.name} (${source.hfAuthor})...`);
 
-  const resp = await fetch(apiUrl, {
+  const resp = await fetchWithRetry(apiUrl, {
     headers: { "User-Agent": HF_USER_AGENT },
     signal: AbortSignal.timeout(30000),
   });
@@ -258,7 +296,7 @@ async function extractFromHfReadme(anthropic, article) {
   // Resolve to a sha so the URL is stable across the run even if branch updates.
   let revision = "main";
   try {
-    const metaResp = await fetch(`https://huggingface.co/api/models/${article.hfModelId}`, {
+    const metaResp = await fetchWithRetry(`https://huggingface.co/api/models/${article.hfModelId}`, {
       headers: { "User-Agent": HF_USER_AGENT },
       signal: AbortSignal.timeout(20000),
     });
@@ -278,7 +316,7 @@ async function extractFromHfReadme(anthropic, article) {
   const readmeUrl = `https://huggingface.co/${article.hfModelId}/raw/${revision}/README.md`;
   let markdown;
   try {
-    const resp = await fetch(readmeUrl, {
+    const resp = await fetchWithRetry(readmeUrl, {
       headers: { "User-Agent": HF_USER_AGENT },
       signal: AbortSignal.timeout(30000),
     });
@@ -381,7 +419,15 @@ async function extractFromHfReadme(anthropic, article) {
   const deduped = deduplicateScores(visionScores, textScores);
   console.log(`     ${deduped.length} unique scores after dedup`);
 
-  return { scores: deduped, publishDate };
+  // Strip HF-specific scaffolding fields before handing scores to the rest of
+  // the pipeline. column_header / row_label / table_caption / notes were used
+  // to drive the column-header guard and audit logging only. `notes` in
+  // particular collides with reviewVariants' "main benchmark table" / "footnote"
+  // semantics — leaving HF prose like "marketing section" in the field would
+  // confuse the existing variant-review LLM.
+  const cleaned = stripHfPromptScaffolding(deduped);
+
+  return { scores: cleaned, publishDate };
 }
 
 // ─── Blog index scanning ─────────────────────────────────────

--- a/scripts/run-pipeline.mjs
+++ b/scripts/run-pipeline.mjs
@@ -57,6 +57,7 @@ const MARKER_DIR = os.tmpdir();
 const MARKER_STARTED = path.join(MARKER_DIR, "ai-race-extraction-started.json");
 const MARKER_COMPLETE = path.join(MARKER_DIR, "ai-race-extraction-complete.json");
 const MARKER_BB_SKIP = path.join(MARKER_DIR, "ai-race-browserbase-skip.json");
+const MARKER_HF_DISCOVERY_FAIL = path.join(MARKER_DIR, "ai-race-hf-discovery-fail.json");
 
 function readMarker(filePath) {
   try { return JSON.parse(fs.readFileSync(filePath, "utf8")); }
@@ -370,7 +371,7 @@ function sourceName(key) {
 /**
  * Build the combined GitHub issue report.
  */
-function buildReport({ changes, flagged, rejected, unknownVariants, extractResult, ingestResult, labFreshness, runDate, regen, extractionCrashed, browserbaseSkipped }) {
+function buildReport({ changes, flagged, rejected, unknownVariants, extractResult, ingestResult, labFreshness, runDate, regen, extractionCrashed, browserbaseSkipped, hfDiscoveryFailures }) {
   const parts = [];
 
   // ─── Header ─────────────────────────────────────────────
@@ -409,6 +410,16 @@ function buildReport({ changes, flagged, rejected, unknownVariants, extractResul
     }
     parts.push("");
     parts.push("</details>");
+    parts.push("");
+  }
+  if (hfDiscoveryFailures && hfDiscoveryFailures.failures?.length > 0) {
+    parts.push("## HF API Discovery Failed");
+    parts.push(`The Hugging Face Hub API returned an error for ${hfDiscoveryFailures.failures.length} source(s). `);
+    parts.push("Other labs ingested normally. Causes: HF rate limit, schema change, API outage, malformed UA blocked.");
+    parts.push("");
+    for (const item of hfDiscoveryFailures.failures) {
+      parts.push(`- **${item.source}** (\`${item.hfAuthor}\`): ${item.reason}`);
+    }
     parts.push("");
   }
 
@@ -587,6 +598,7 @@ async function main() {
   let extractResult = null;
   let extractionCrashed = false;
   let browserbaseSkipped = null; // payload from .browserbase-skip.json if present
+  let hfDiscoveryFailures = null; // payload from .hf-discovery-fail.json if present
 
   if (SKIP_EXTRACT) {
     console.log("\nStep 2: Extraction skipped (--skip-extract)");
@@ -595,6 +607,7 @@ async function main() {
     unlinkMarker(MARKER_STARTED);
     unlinkMarker(MARKER_COMPLETE);
     unlinkMarker(MARKER_BB_SKIP);
+    unlinkMarker(MARKER_HF_DISCOVERY_FAIL);
 
     const extractArgs = ["--no-report"];
     if (DRY_RUN) extractArgs.push("--dry-run");
@@ -612,6 +625,7 @@ async function main() {
     // Marker file inspection — single source of truth for "did extraction actually finish?"
     const completeMarker = readMarker(MARKER_COMPLETE);
     const bbSkipMarker = readMarker(MARKER_BB_SKIP);
+    const hfFailMarker = readMarker(MARKER_HF_DISCOVERY_FAIL);
 
     if (!completeMarker) {
       // Subprocess didn't write the complete marker → it crashed somewhere
@@ -622,11 +636,16 @@ async function main() {
       browserbaseSkipped = bbSkipMarker;
       console.warn(`\n  Warning: Browserbase was unavailable for ${bbSkipMarker.skippedUrls?.length || 0} article(s).`);
     }
+    if (hfFailMarker) {
+      hfDiscoveryFailures = hfFailMarker;
+      console.warn(`\n  Warning: HF API discovery failed for ${hfFailMarker.failures?.length || 0} source(s).`);
+    }
 
     // Tidy up — orchestrator owns marker lifecycle
     unlinkMarker(MARKER_STARTED);
     unlinkMarker(MARKER_COMPLETE);
     unlinkMarker(MARKER_BB_SKIP);
+    unlinkMarker(MARKER_HF_DISCOVERY_FAIL);
   }
 
   // ─── Step 3: Run ingestion ──────────────────────────────
@@ -732,6 +751,7 @@ async function main() {
     regen,
     extractionCrashed,
     browserbaseSkipped,
+    hfDiscoveryFailures,
   });
 
   console.log(`  Title: ${report.title}`);

--- a/scripts/validate-extraction.mjs
+++ b/scripts/validate-extraction.mjs
@@ -115,12 +115,12 @@ const GROUND_TRUTHS = [
     ],
   },
   // ── Hugging Face API path (no browser) ──────────────────────────
-  // GT URLs pin to a specific commit sha so the GT validates exactly the README
-  // content the scores correspond to. If the lab pushes a README revision, the
-  // sha needs updating here. Production extraction uses the latest sha at runtime,
-  // so a stale GT does NOT block the pipeline — it just surfaces in this report.
-  //
-  // To refresh: GET /api/models/<id>, copy `.sha`, paste into `revision`.
+  // `revision: "main"` follows the lab's latest README. If a lab edits scores
+  // post-launch, this validation will start failing — which is the signal we
+  // want (production also reads the latest sha, so divergence between GT and
+  // production is itself a regression of interest). To pin a specific commit
+  // (e.g. while debugging a known-good GT), replace `"main"` with the sha
+  // returned by `GET /api/models/<id>`.
   {
     lab: "chinese",
     slug: "deepseek",

--- a/scripts/validate-extraction.mjs
+++ b/scripts/validate-extraction.mjs
@@ -26,8 +26,13 @@ import { fileURLToPath } from "url";
 import { BrowserPool } from "../lib/browser.mjs";
 
 const require = createRequire(import.meta.url);
-const { filterContentImages, buildTextBlock, deduplicateScores } = require("../lib/extraction.js");
-const { extractScoresFromText, extractScoresFromImage } = require("../lib/llm-extract.js");
+const {
+  filterContentImages, buildTextBlock, deduplicateScores, parseHfReadmeImages,
+} = require("../lib/extraction.js");
+const {
+  extractScoresFromText, extractScoresFromImage, extractScoresFromHfMarkdown,
+  columnHeaderGuard,
+} = require("../lib/llm-extract.js");
 const { LAB_SOURCES } = require("../lib/lab-sources.js");
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -109,24 +114,89 @@ const GROUND_TRUTHS = [
       { benchmark: /mmmlu/i, score: 88.9 },
     ],
   },
+  // ── Hugging Face API path (no browser) ──────────────────────────
+  // GT URLs pin to a specific commit sha so the GT validates exactly the README
+  // content the scores correspond to. If the lab pushes a README revision, the
+  // sha needs updating here. Production extraction uses the latest sha at runtime,
+  // so a stale GT does NOT block the pipeline — it just surfaces in this report.
+  //
+  // To refresh: GET /api/models/<id>, copy `.sha`, paste into `revision`.
   {
     lab: "chinese",
-    labName: "DeepSeek",
-    url: "https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp",
-    model: "DeepSeek-V3.2-Exp",
-    minSections: 5,
-    minExpectedScoreCount: 8,
+    slug: "deepseek",
+    labName: "DeepSeek (HF)",
+    kind: "hf-api",
+    hfModelId: "deepseek-ai/DeepSeek-V4-Pro",
+    revision: "main",
+    model: "DeepSeek-V4-Pro",
+    minExpectedScoreCount: 5,
     expectedScores: [
-      { benchmark: /gpqa.?diamond/i, score: 79.9 },
-      { benchmark: /humanity.*last.*exam|hle/i, score: 19.8 },
-      { benchmark: /mmlu.?pro/i, score: 85.0 },
+      { benchmark: /gpqa.?diamond/i, score: 90.1 },
+      { benchmark: /hle|humanity.*last.*exam/i, score: 37.7 },
+      { benchmark: /mmlu.?pro/i, score: 87.5 },
+    ],
+  },
+  {
+    lab: "chinese",
+    slug: "kimi",
+    labName: "Kimi (HF)",
+    kind: "hf-api",
+    hfModelId: "moonshotai/Kimi-K2.6",
+    revision: "main",
+    model: "Kimi-K2.6",
+    minExpectedScoreCount: 3,
+    expectedScores: [
+      { benchmark: /swe.?bench pro/i, score: 58.6 },
+      { benchmark: /swe.?bench verified/i, score: 80.2 },
+      { benchmark: /gpqa/i, score: 90.5 },
+    ],
+  },
+  {
+    lab: "chinese",
+    slug: "minimax",
+    labName: "MiniMax (HF)",
+    kind: "hf-api",
+    hfModelId: "MiniMaxAI/MiniMax-M2.7",
+    revision: "main",
+    model: "MiniMax-M2.7",
+    // M2.7's README uses non-standard benchmark names (e.g. "SWE-Pro" not
+    // "SWE-bench Pro"), so most scores land in untracked. Smoke-test only:
+    // confirm at least one prose-style score was extracted.
+    minExpectedScoreCount: 5,
+    expectedScores: [
+      { benchmark: /swe.?pro|swe.?bench/i, score: 56.22 },
+    ],
+  },
+  {
+    lab: "chinese",
+    slug: "zhipu",
+    labName: "Zhipu (HF)",
+    kind: "hf-api",
+    hfModelId: "zai-org/GLM-5.1",
+    revision: "main",
+    model: "GLM-5.1",
+    minExpectedScoreCount: 4,
+    expectedScores: [
+      { benchmark: /hle|humanity.*last.*exam/i, score: 31 },
+      { benchmark: /gpqa/i, score: 86.2 },
+      { benchmark: /swe.?bench pro/i, score: 58.4 },
     ],
   },
 ];
 
-// Look up the source's `useBrowserbase` flag so validation matches production.
-function browserKindForLab(lab) {
-  const source = LAB_SOURCES.find(s => s.lab === lab);
+// Determine the discovery/extraction kind for a ground truth.
+// HF API GTs explicitly set `kind: "hf-api"`. For browser-based GTs, we look
+// up the source's `useBrowserbase` flag so validation matches production.
+//
+// Note: `chinese` maps to multiple sources (4 HF + Qwen). For browser-based
+// chinese GTs (Qwen), we look up by slug. For HF-API GTs, the `kind` field
+// dispatches before browserKindForGt is consulted.
+function browserKindForGt(gt) {
+  if (gt.kind === "hf-api") return "hf-api";
+  // Prefer slug lookup when present (disambiguates multi-source labs like chinese).
+  const source = gt.slug
+    ? LAB_SOURCES.find(s => s.slug === gt.slug)
+    : LAB_SOURCES.find(s => s.lab === gt.lab && !s.scanMethod);
   return source?.useBrowserbase === true ? "browserbase" : "local";
 }
 
@@ -347,6 +417,133 @@ async function validateOne(browser, anthropic, gt) {
   }
 }
 
+// ─── HF API validation (no browser) ─────────────────────────
+// Mirrors scripts/extract-model-cards.mjs#extractFromHfReadme but without
+// DB writes or report generation. Uses the GT's pinned revision sha so the
+// scores remain stable; production uses the latest sha at runtime.
+
+const HF_USER_AGENT = "ai-race-pipeline/1.0 (+https://ai-race.vercel.app)";
+
+async function validateOneHfApi(anthropic, gt) {
+  const revision = gt.revision || "main";
+  const readmeUrl = `https://huggingface.co/${gt.hfModelId}/raw/${revision}/README.md`;
+
+  let markdown;
+  try {
+    const resp = await fetch(readmeUrl, {
+      headers: { "User-Agent": HF_USER_AGENT },
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!resp.ok) {
+      return {
+        lab: gt.labName,
+        renderOk: false,
+        passed: false,
+        message: `README fetch ${resp.status} ${resp.statusText} for ${gt.hfModelId}@${revision}`,
+      };
+    }
+    markdown = await resp.text();
+  } catch (err) {
+    return {
+      lab: gt.labName,
+      renderOk: false,
+      passed: false,
+      message: `README fetch error: ${err.message.substring(0, 200)}`,
+    };
+  }
+
+  if (!markdown || markdown.trim().length < 100) {
+    return {
+      lab: gt.labName,
+      renderOk: false,
+      passed: false,
+      message: `README too short (${markdown?.length || 0} chars)`,
+    };
+  }
+
+  if (QUICK_MODE) {
+    return {
+      lab: gt.labName,
+      renderOk: true,
+      passed: true,
+      message: `README fetched (${markdown.length} chars, quick mode skipped LLM)`,
+    };
+  }
+
+  // Image-following: parse + download + vision (cap to 5 like production)
+  const imageUrls = parseHfReadmeImages(markdown, gt.hfModelId, revision).slice(0, 5);
+  const visionScores = [];
+  for (const imgUrl of imageUrls) {
+    const downloaded = await downloadImage(imgUrl);
+    if (!downloaded) continue;
+    try {
+      const scores = await extractScoresFromImage(anthropic, {
+        base64Data: downloaded.base64,
+        mediaType: downloaded.mediaType,
+        modelName: gt.model,
+      });
+      visionScores.push(...scores);
+    } catch (err) { console.warn(`    Image extraction failed: ${err.message.substring(0, 100)}`); }
+  }
+
+  // Markdown text extraction with column-header guard
+  let textScores = [];
+  try {
+    const raw = await extractScoresFromHfMarkdown(anthropic, { markdown, modelName: gt.model });
+    const guarded = columnHeaderGuard(raw, gt.model);
+    textScores = guarded.kept;
+  } catch (err) { console.warn(`    Markdown extraction failed: ${err.message.substring(0, 100)}`); }
+
+  const allScores = deduplicateScores(visionScores, textScores);
+
+  if (allScores.length === 0) {
+    return {
+      lab: gt.labName,
+      renderOk: true,
+      passed: false,
+      totalExtracted: 0,
+      message: `README fetched (${markdown.length} chars) but extraction yielded ZERO scores. Likely LLM prompt regression or column-guard over-aggression.`,
+    };
+  }
+
+  if (gt.minExpectedScoreCount && allScores.length < gt.minExpectedScoreCount) {
+    return {
+      lab: gt.labName,
+      renderOk: true,
+      passed: false,
+      totalExtracted: allScores.length,
+      message: `Only ${allScores.length} scores extracted (expected ≥${gt.minExpectedScoreCount}).`,
+    };
+  }
+
+  // GT score sample matching: tolerate `score: null` entries (smoke-only — pattern must match SOMETHING)
+  const found = [];
+  const missing = [];
+  for (const expected of gt.expectedScores) {
+    const match = allScores.find(s => {
+      const combined = `${s.benchmark} ${s.model_variant || ""}`;
+      const benchMatch = expected.benchmark.test(s.benchmark) || expected.benchmark.test(combined);
+      const scoreMatch = expected.score == null || Math.abs(s.score - expected.score) < 0.5;
+      return benchMatch && scoreMatch;
+    });
+    if (match) found.push({ expected: expected.score, got: match.score, benchmark: match.benchmark });
+    else missing.push({ score: expected.score, pattern: expected.benchmark.source });
+  }
+
+  return {
+    lab: gt.labName,
+    renderOk: true,
+    passed: missing.length === 0,
+    totalExtracted: allScores.length,
+    found: found.length,
+    missing: missing.length,
+    missingDetails: missing,
+    message: missing.length === 0
+      ? `${found.length}/${gt.expectedScores.length} GT scores found (${allScores.length} total)`
+      : `${found.length}/${gt.expectedScores.length} found, MISSING: ${missing.map(m => `${m.pattern}=${m.score ?? "*"}`).join(", ")}`,
+  };
+}
+
 // ─── Pass 3: fresh-article canary ────────────────────────────
 // Defends against ground truths fossilizing. Fetches OpenAI's RSS feed,
 // picks the newest article matching the article path pattern, opens it via
@@ -478,14 +675,26 @@ async function main() {
 
   const pool = new BrowserPool();
 
-  // Group ground truths by browser kind.
-  const localGts = GROUND_TRUTHS.filter(gt => browserKindForLab(gt.lab) === "local");
-  const bbGts = GROUND_TRUTHS.filter(gt => browserKindForLab(gt.lab) === "browserbase");
+  // Group ground truths by validation kind.
+  const localGts = GROUND_TRUTHS.filter(gt => browserKindForGt(gt) === "local");
+  const bbGts = GROUND_TRUTHS.filter(gt => browserKindForGt(gt) === "browserbase");
+  const hfApiGts = GROUND_TRUTHS.filter(gt => browserKindForGt(gt) === "hf-api");
 
   let allResults = [];
   try {
     allResults = allResults.concat(await runPassForKind(pool, anthropic, "local", localGts));
     allResults = allResults.concat(await runPassForKind(pool, anthropic, "browserbase", bbGts));
+
+    // HF API pass: no browser pool, parallel-ish per GT (each is just HTTP + LLM).
+    if (hfApiGts.length > 0) {
+      console.log(`\nPass: hf-api (${hfApiGts.length} ground truth${hfApiGts.length === 1 ? "" : "s"})`);
+      for (const gt of hfApiGts) {
+        process.stdout.write(`  ${gt.labName}... `);
+        const result = await validateOneHfApi(anthropic, gt);
+        allResults.push(result);
+        console.log(result.message);
+      }
+    }
 
     // Pass 3: fresh-article canary (only if we have a Browserbase-flagged source).
     if (bbGts.length > 0) {

--- a/tests/extraction-hf.test.js
+++ b/tests/extraction-hf.test.js
@@ -1,0 +1,264 @@
+import { describe, it, expect } from "vitest";
+
+const { filterHfModels, parseHfReadmeImages } = require("../lib/extraction.js");
+const { columnHeaderGuard } = require("../lib/llm-extract.js");
+
+// ─── filterHfModels ──────────────────────────────────────────
+
+describe("filterHfModels", () => {
+  const NOW = new Date("2026-05-07T00:00:00Z");
+  const recent = "2026-05-01T00:00:00Z";
+  const old = "2025-01-01T00:00:00Z";
+
+  function model(overrides = {}) {
+    return {
+      id: "lab/Model-1",
+      createdAt: recent,
+      lastModified: recent,
+      pipeline_tag: "text-generation",
+      tags: ["transformers"],
+      ...overrides,
+    };
+  }
+
+  it("keeps a normal flagship model card", () => {
+    const out = filterHfModels([model()], { now: NOW });
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("lab/Model-1");
+  });
+
+  it("drops models last-modified outside the 30-day window", () => {
+    const out = filterHfModels([model({ lastModified: old })], { now: NOW });
+    expect(out).toHaveLength(0);
+  });
+
+  it("drops models with non-text pipeline_tag (TTS, image-feature-extraction, etc.)", () => {
+    expect(filterHfModels([model({ pipeline_tag: "text-to-speech" })], { now: NOW })).toHaveLength(0);
+    expect(filterHfModels([model({ pipeline_tag: "image-feature-extraction" })], { now: NOW })).toHaveLength(0);
+    expect(filterHfModels([model({ pipeline_tag: "automatic-speech-recognition" })], { now: NOW })).toHaveLength(0);
+  });
+
+  it("keeps text-generation and image-text-to-text", () => {
+    expect(filterHfModels([model({ pipeline_tag: "text-generation" })], { now: NOW })).toHaveLength(1);
+    expect(filterHfModels([model({ id: "lab/Vision-1", pipeline_tag: "image-text-to-text" })], { now: NOW })).toHaveLength(1);
+  });
+
+  it("drops null/missing pipeline_tag (covers DeepSeek-V4-Flash-Base case)", () => {
+    expect(filterHfModels([model({ pipeline_tag: null })], { now: NOW })).toHaveLength(0);
+    expect(filterHfModels([model({ pipeline_tag: undefined })], { now: NOW })).toHaveLength(0);
+  });
+
+  it("drops -Base/-FP8/-AWQ/-GPTQ/-Int4/-Int8/-GGUF suffix variants", () => {
+    const ids = [
+      "lab/Model-Base", "lab/Model-FP8", "lab/Model-AWQ",
+      "lab/Model-GPTQ", "lab/Model-Int4", "lab/Model-Int8", "lab/Model-GGUF",
+    ];
+    for (const id of ids) {
+      expect(filterHfModels([model({ id })], { now: NOW })).toHaveLength(0);
+    }
+  });
+
+  it("keeps models whose name happens to contain Base/FP8 mid-string but not as suffix", () => {
+    expect(filterHfModels([model({ id: "lab/Baseline-Model" })], { now: NOW })).toHaveLength(1);
+    expect(filterHfModels([model({ id: "lab/FP8-Improved-Model" })], { now: NOW })).toHaveLength(1);
+  });
+
+  it("KEEPS natively-fp8 flagships (e.g. DeepSeek V4, MiniMax M2)", () => {
+    // DeepSeek V4 and MiniMax M2.7 ship with `fp8` in tags as a native-precision
+    // marker, not as a derivative-quantization marker. Excluding on bare quant
+    // tags would drop the flagships of two of our four HF labs.
+    expect(filterHfModels([model({ tags: ["transformers", "fp8", "endpoints_compatible"] })], { now: NOW })).toHaveLength(1);
+    expect(filterHfModels([model({ tags: ["8-bit", "fp8", "region:us"] })], { now: NOW })).toHaveLength(1);
+  });
+
+  it("drops models tagged as derivative quantizations via base_model:quantized:", () => {
+    expect(filterHfModels([model({
+      tags: ["transformers", "base_model:quantized:lab/Original-Model"],
+    })], { now: NOW })).toHaveLength(0);
+  });
+
+  it("drops malformed entries gracefully", () => {
+    expect(filterHfModels([null, undefined, {}, { id: "x" }, "string"], { now: NOW })).toHaveLength(0);
+  });
+
+  it("returns empty array on non-array input", () => {
+    expect(filterHfModels(null)).toEqual([]);
+    expect(filterHfModels({})).toEqual([]);
+    expect(filterHfModels("not-an-array")).toEqual([]);
+  });
+
+  it("respects the limit parameter", () => {
+    const many = Array.from({ length: 50 }, (_, i) => model({
+      id: `lab/Model-${i}`,
+      createdAt: new Date(NOW.getTime() - i * 1000).toISOString(),
+    }));
+    expect(filterHfModels(many, { now: NOW, limit: 5 })).toHaveLength(5);
+    expect(filterHfModels(many, { now: NOW, limit: 20 })).toHaveLength(20);
+  });
+
+  it("sorts by createdAt descending (newest first)", () => {
+    const inputs = [
+      model({ id: "lab/Older", createdAt: "2026-04-01T00:00:00Z" }),
+      model({ id: "lab/Newest", createdAt: "2026-05-01T00:00:00Z" }),
+      model({ id: "lab/Middle", createdAt: "2026-04-15T00:00:00Z" }),
+    ];
+    const out = filterHfModels(inputs, { now: NOW });
+    expect(out.map(m => m.id)).toEqual(["lab/Newest", "lab/Middle", "lab/Older"]);
+  });
+});
+
+// ─── parseHfReadmeImages ─────────────────────────────────────
+
+describe("parseHfReadmeImages", () => {
+  it("extracts markdown image syntax", () => {
+    const md = "Some prose\n\n![chart](figures/bench.png)\n\nMore prose";
+    const out = parseHfReadmeImages(md, "lab/Model", "main");
+    expect(out).toEqual([
+      "https://huggingface.co/lab/Model/resolve/main/figures/bench.png",
+    ]);
+  });
+
+  it("extracts HTML img tags (common inside <p align=center> in HF READMEs)", () => {
+    const md = `<p align="center"><img width="100%" src="figures/benchmark_overview.png"></p>`;
+    const out = parseHfReadmeImages(md, "lab/Model", "abc123");
+    expect(out).toEqual([
+      "https://huggingface.co/lab/Model/resolve/abc123/figures/benchmark_overview.png",
+    ]);
+  });
+
+  it("preserves absolute URLs (e.g., GitHub raw)", () => {
+    const md = `![](https://raw.githubusercontent.com/lab/repo/main/bench.png)`;
+    const out = parseHfReadmeImages(md, "lab/Model", "main");
+    expect(out).toEqual(["https://raw.githubusercontent.com/lab/repo/main/bench.png"]);
+  });
+
+  it("skips .svg, .gif, .webp images (not vision-friendly)", () => {
+    const md = `![logo](assets/logo.svg)\n![demo](assets/demo.gif)\n![chart](assets/chart.png)\n![ico](assets/ico.webp)`;
+    const out = parseHfReadmeImages(md, "lab/Model", "main");
+    expect(out).toEqual(["https://huggingface.co/lab/Model/resolve/main/assets/chart.png"]);
+  });
+
+  it("deduplicates repeated references", () => {
+    const md = `![a](figures/x.png)\n![b](figures/x.png)`;
+    const out = parseHfReadmeImages(md, "lab/Model", "main");
+    expect(out).toHaveLength(1);
+  });
+
+  it("handles ./ and / prefixed relative paths", () => {
+    const md = `![a](./figures/x.png)\n![b](/figures/y.png)`;
+    const out = parseHfReadmeImages(md, "lab/Model", "main");
+    expect(out).toEqual([
+      "https://huggingface.co/lab/Model/resolve/main/figures/x.png",
+      "https://huggingface.co/lab/Model/resolve/main/figures/y.png",
+    ]);
+  });
+
+  it("returns empty for empty/missing input", () => {
+    expect(parseHfReadmeImages("", "lab/Model", "main")).toEqual([]);
+    expect(parseHfReadmeImages(null, "lab/Model", "main")).toEqual([]);
+    expect(parseHfReadmeImages("![](x.png)", null, "main")).toEqual([]);
+  });
+
+  it("captures both markdown + HTML images in the same blob", () => {
+    const md = `
+![one](figures/one.png)
+<img src="figures/two.jpg">
+<p align="center"><img alt="three" src="figures/three.png" width="80%"></p>
+`;
+    const out = parseHfReadmeImages(md, "lab/Model", "main");
+    expect(out).toHaveLength(3);
+    expect(out).toContain("https://huggingface.co/lab/Model/resolve/main/figures/one.png");
+    expect(out).toContain("https://huggingface.co/lab/Model/resolve/main/figures/two.jpg");
+    expect(out).toContain("https://huggingface.co/lab/Model/resolve/main/figures/three.png");
+  });
+});
+
+// ─── columnHeaderGuard ───────────────────────────────────────
+
+describe("columnHeaderGuard", () => {
+  it("keeps scores without column_header (prose extractions)", () => {
+    const scores = [
+      { benchmark: "GPQA", score: 90.1 },
+      { benchmark: "HLE", score: 38, model_variant: "with tools" },
+    ];
+    const { kept, dropped } = columnHeaderGuard(scores, "MiniMax-M2.7");
+    expect(kept).toHaveLength(2);
+    expect(dropped).toHaveLength(0);
+  });
+
+  it("keeps scores whose column_header shares a token with modelName", () => {
+    const scores = [
+      { benchmark: "GPQA", score: 90.1, column_header: "MiniMax-M2.7" },
+      { benchmark: "HLE", score: 37.7, column_header: "M2.7" },
+    ];
+    const { kept } = columnHeaderGuard(scores, "MiniMax-M2.7");
+    expect(kept).toHaveLength(2);
+  });
+
+  it("drops scores whose column_header does not match the target model", () => {
+    const scores = [
+      { benchmark: "GPQA", score: 91.0, column_header: "GPT-5.5" },
+      { benchmark: "GPQA", score: 89.5, column_header: "Claude 4.7" },
+      { benchmark: "GPQA", score: 88.0, column_header: "Gemini 3" },
+      { benchmark: "GPQA", score: 90.1, column_header: "Kimi-K2.6" },
+    ];
+    const { kept, dropped } = columnHeaderGuard(scores, "Kimi-K2.6");
+    expect(kept).toHaveLength(1);
+    expect(kept[0].column_header).toBe("Kimi-K2.6");
+    expect(dropped).toHaveLength(3);
+  });
+
+  it("handles suffix variants on the column header (Pro/Flash/Max/Instruct/Base)", () => {
+    const scores = [
+      { benchmark: "GPQA", score: 90.1, column_header: "DeepSeek-V4-Pro" },
+      { benchmark: "GPQA", score: 87.5, column_header: "DeepSeek-V4" },
+    ];
+    const { kept } = columnHeaderGuard(scores, "DeepSeek-V4");
+    expect(kept.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does NOT catch same-family-different-version (relies on prompt for that)", () => {
+    // GLM-4.6 vs GLM-4.7 — both share the "glm" token, so the programmatic
+    // guard keeps both. The LLM prompt is responsible for not extracting
+    // GLM-4.6 rows when the target is GLM-4.7. This test documents the gap.
+    const scores = [
+      { benchmark: "GPQA", score: 88.0, column_header: "GLM-4.6" },
+      { benchmark: "GPQA", score: 90.0, column_header: "GLM-4.7" },
+    ];
+    const { kept, dropped } = columnHeaderGuard(scores, "GLM-4.7");
+    expect(kept).toHaveLength(2);
+    expect(dropped).toHaveLength(0);
+  });
+
+  it("handles missing/empty modelName by passing scores through", () => {
+    const scores = [{ benchmark: "GPQA", score: 90, column_header: "Anything" }];
+    expect(columnHeaderGuard(scores, "").kept).toEqual(scores);
+    expect(columnHeaderGuard(scores, null).kept).toEqual(scores);
+  });
+
+  it("annotates dropped scores with a reason for audit", () => {
+    const scores = [{ benchmark: "GPQA", score: 90, column_header: "GPT-5.5" }];
+    const { dropped } = columnHeaderGuard(scores, "Kimi-K2.6");
+    expect(dropped[0]._dropReason).toContain("GPT-5.5");
+    expect(dropped[0]._dropReason).toContain("Kimi-K2.6");
+  });
+
+  it("drops -Base columns when target is the instructed model", () => {
+    const scores = [
+      { benchmark: "MMLU-Pro", score: 73.5, column_header: "DeepSeek-V4-Pro-Base" },
+      { benchmark: "MMLU-Pro", score: 87.5, column_header: "DS-V4-Pro Max" },
+    ];
+    const { kept, dropped } = columnHeaderGuard(scores, "DeepSeek-V4-Pro");
+    expect(kept).toHaveLength(1);
+    expect(kept[0].column_header).toBe("DS-V4-Pro Max");
+    expect(dropped[0]._dropReason).toContain("Base checkpoint");
+  });
+
+  it("KEEPS -Base columns when the target itself is a Base model (rare but defensible)", () => {
+    const scores = [
+      { benchmark: "MMLU-Pro", score: 73.5, column_header: "DeepSeek-V4-Pro-Base" },
+    ];
+    const { kept } = columnHeaderGuard(scores, "DeepSeek-V4-Pro-Base");
+    expect(kept).toHaveLength(1);
+  });
+});

--- a/tests/extraction-hf.test.js
+++ b/tests/extraction-hf.test.js
@@ -261,4 +261,13 @@ describe("columnHeaderGuard", () => {
     const { kept } = columnHeaderGuard(scores, "DeepSeek-V4-Pro-Base");
     expect(kept).toHaveLength(1);
   });
+
+  it("does not match `Base` mid-word (Baseline, BabyBench, database)", () => {
+    const scores = [
+      { benchmark: "BabyBench", score: 90, column_header: "Kimi-K2.6" },
+      { benchmark: "Baseline-Suite", score: 70, column_header: "Kimi-K2.6" },
+    ];
+    const { kept } = columnHeaderGuard(scores, "Kimi-K2.6");
+    expect(kept).toHaveLength(2);
+  });
 });

--- a/tests/lab-sources.test.js
+++ b/tests/lab-sources.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+
+const { LAB_SOURCES } = require("../lib/lab-sources.js");
+
+describe("LAB_SOURCES", () => {
+  it("includes the four HF API sources for Chinese Leaders", () => {
+    const hfSources = LAB_SOURCES.filter(s => s.scanMethod === "huggingfaceApi");
+    const slugs = hfSources.map(s => s.slug).sort();
+    expect(slugs).toEqual(["deepseek", "kimi", "minimax", "zhipu"]);
+    for (const s of hfSources) {
+      expect(s.lab).toBe("chinese");
+      expect(s.hfAuthor).toBeTruthy();
+      expect(typeof s.hfAuthor).toBe("string");
+      expect(s.minExpectedArticles).toBeGreaterThanOrEqual(1); // never 0 — silences failure signals
+    }
+  });
+
+  it("uses correct HF org names for each lab", () => {
+    const byName = Object.fromEntries(
+      LAB_SOURCES.filter(s => s.scanMethod === "huggingfaceApi").map(s => [s.slug, s.hfAuthor])
+    );
+    expect(byName.deepseek).toBe("deepseek-ai");
+    expect(byName.kimi).toBe("moonshotai");
+    expect(byName.minimax).toBe("MiniMaxAI");
+    expect(byName.zhipu).toBe("zai-org");
+  });
+
+  it("Qwen retains its existing card-scanner config (not migrated to HF)", () => {
+    const qwen = LAB_SOURCES.find(s => s.slug === "qwen");
+    expect(qwen).toBeTruthy();
+    expect(qwen.scanMethod).toBe("qwenCards");
+    expect(qwen.indexUrl).toBe("https://qwen.ai/research");
+  });
+
+  it("OpenAI keeps useBrowserbase: true", () => {
+    const openai = LAB_SOURCES.find(s => s.lab === "openai");
+    expect(openai.useBrowserbase).toBe(true);
+  });
+
+  it("HF sources do not set useBrowserbase (no browser path needed)", () => {
+    for (const s of LAB_SOURCES.filter(s => s.scanMethod === "huggingfaceApi")) {
+      expect(s.useBrowserbase).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the broken DeepSeek HF DOM scanner with a pure-HTTP path against the Hugging Face Hub API, and extends to three more Chinese labs that publish flagship model cards on HF: Kimi/Moonshot, MiniMax, Zhipu. Qwen retains its existing `qwen.ai` card scanner; ByteDance/Doubao parked (no flagship on HF).

Closes the **DeepSeek extraction** part of the *Fix automated extraction reliability* task in TASKS.md, and partially closes the **Chinese Leaders automated extraction config** task (Kimi/MiniMax/Zhipu added; ByteDance still pending different surface).

## Architecture

| Lab | Discovery | Extraction |
|-----|-----------|------------|
| OpenAI | RSS feed | Browserbase (cloud) |
| Anthropic | Blog DOM scan | Local Playwright |
| Google DeepMind | Blog DOM scan | Local Playwright |
| xAI | Blog DOM scan | Local Playwright |
| **DeepSeek** | **HF API (new)** | **Pure HTTP + LLM (new)** |
| **Kimi** | **HF API (new)** | **Pure HTTP + LLM (new)** |
| **MiniMax** | **HF API (new)** | **Pure HTTP + LLM (new)** |
| **Zhipu** | **HF API (new)** | **Pure HTTP + LLM (new)** |
| Qwen | qwen.ai card scanner | Local Playwright |

## Key design decisions (red-teamed twice)

**30-day window via `lastModified`** instead of `createdAt`. Labs commonly push a stub README at model creation and fill in the eval section days later — `createdAt` would miss those. Re-processing fires when `lastModified > extracted_at` (existing delete-by-source_url + insert handles idempotency).

**Metadata-based filtering, not name-based.** `pipeline_tag in {text-generation, image-text-to-text}`, `-Base/-FP8/-AWQ/-GPTQ/-Int4/-Int8/-GGUF` suffix exclusion, plus `base_model:quantized:` tag prefix. Critically does **NOT** exclude on bare `fp8`/`awq` tags — DeepSeek V4 and MiniMax M2.7 are natively trained in fp8 and the tag appears on the flagship.

**HF-specific LLM prompt** with column-header echo and same-family disambiguation. Backstopped by a pure-function `columnHeaderGuard` that drops misidentified columns and explicitly rejects `-Base` checkpoint columns when the target is the instructed model. **16K output budget** (vs 4K for blog extraction) — DeepSeek READMEs emit ~80 scores across 3 eval tables; 4K silently truncated the tool_use mid-stream and returned zero scores.

**Third-party scaffolds in HARNESS_KEYWORDS**: `openhands`, `webexplorer`, `claude-code`, `trae`, `aider`, `cline`, `roo-code`. Common in Chinese lab READMEs as harness names; without these, harnessed scores would supersede verified scores in dedup.

**No browser at all** for HF sources — skips `BrowserPool` entirely, sidesteps anti-bot/render flakiness that defeated the prior DOM scanner.

## Failure isolation

New `.hf-discovery-fail.json` marker file mirrors the existing Browserbase pattern. If HF API errors for one lab, the orchestrator surfaces it in the same GitHub issue under "HF API Discovery Failed" and other labs ingest normally.

## Validation

- **209 unit tests pass** (was 197). Two new test files: `tests/lab-sources.test.js`, `tests/extraction-hf.test.js`. Includes synthetic-table column-guard test, base-checkpoint guard test, native-fp8-flagship test, version-disambiguation gap documented.
- **`scripts/validate-extraction.mjs`** extended with new `kind: "hf-api"` validation pass. 4 new pinned-revision ground truths (DeepSeek V4-Pro, Kimi K2.6, MiniMax M2.7, GLM-5.1).
- **Live dry-run** (`--dry-run --lab chinese`): 9 articles processed, 310 raw scores, 31 ingested across all 4 labs + Qwen, 0 flagged, 2 rejected, column-header guard dropped 2 mismatched columns. Sample ingested scores:
  - DeepSeek V4-Pro: GPQA 90.1 [Max], 89.1 [High], 72.9 [Non-Think]; HLE 37.7/34.5/7.7 across modes
  - Kimi K2.6: SWE-Pro 58.6, SWE-Verified 80.2, GPQA 90.5
  - GLM-5.1: HLE 31, HLE 52.3 [with Tools], GPQA 86.2, SWE-Pro 58.4

## Test plan

- [ ] Pull and review the diff (especially `lib/llm-extract.js` prompt and `lib/extraction.js` filterHfModels)
- [ ] `npm test` should pass 209/209
- [ ] `node scripts/extract-model-cards.mjs --dry-run --lab chinese` reproduces the dry-run output above
- [ ] Spot-check that DeepSeek-V4-Pro-Base and DeepSeek-V4-Flash-Base columns are NOT in the ingested set (Base guard working)
- [ ] Validate-extraction smoke pass (`node scripts/validate-extraction.mjs --quick`)
- [ ] Merge → next Thursday's pipeline run picks up DeepSeek/Kimi/MiniMax/Zhipu automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)