### PR TITLE
Add ARC-AGI-3 + OSWorld-Verified benchmarks

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,11 +20,13 @@ const BENCHMARK_SOURCE_MAP = {
   "aime":          "Epoch AI",
   "arc-agi-1":     "ARC Prize",
   "arc-agi-2":     "ARC Prize",
+  "arc-agi-3":     "ARC Prize",
   "hle":           "Artificial Analysis",
   "swe-bench-verified": "SWE-bench",
   "swe-bench-pro": "Scale AI SEAL",
   "frontiermath":  "Epoch AI",
   "math-l5":       "Epoch AI",
+  "osworld-verified": "Epoch AI",
 };
 
 const COST_SOURCE = "Artificial Analysis";
@@ -83,6 +85,7 @@ const BENCHMARK_COLORS = {
   "swe-bench-verified": "#10b981",
   "arc-agi-1":     "#f59e0b",
   "arc-agi-2":     "#f97316",
+  "arc-agi-3":     "#c084fc",
   "hle":           "#8b5cf6",
   "gpqa":          "#06b6d4",
   "aime":          "#ef4444",
@@ -90,6 +93,7 @@ const BENCHMARK_COLORS = {
   "humaneval":     "#6ee7b7",
   "frontiermath":  "#f472b6",
   "math-l5":       "#fb7185",
+  "osworld-verified": "#fbbf24",
 };
 
 // Colors for cost benchmarks

--- a/app.js
+++ b/app.js
@@ -503,7 +503,7 @@ function buildFrontierDatasets() {
       pointHoverBackgroundColor: isInactive ? INACTIVE_COLOR : color,
       tension: 0.3,
       spanGaps: true,
-      order: isInactive ? 1 : 0, // inactive lines render behind active
+      order: isInactive ? 1 : 0, // higher order draws first → behind; active stays on top
     };
 
     if (isInactive) {
@@ -521,52 +521,50 @@ function buildDatasets() {
 }
 
 // ─── Inactivity marker plugin ────────────────────────────────
+// Renders per-dataset in afterDatasetDraw so the marker sits with its inactive line
+// in z-order — active lines drawn later (lower `order` value) cover it where they
+// cross, and tooltips drawn afterwards render on top. Previously used afterDraw, which
+// put the marker above every dataset and every tooltip.
 const inactivityMarkerPlugin = {
   id: "inactivityMarker",
-  afterDraw(chart) {
+  afterDatasetDraw(chart, args) {
     if (currentMode !== "frontier") return;
+    const ds = chart.data.datasets[args.index];
+    if (!ds._isInactive || !ds._activeUntil) return;
+    if (!chart.isDatasetVisible(args.index)) return;
+
+    const qIdx = TIME_LABELS.indexOf(ds._activeUntil);
+    if (qIdx < 0) return;
+    if (ds.data[qIdx] == null) return;
+
+    const meta = chart.getDatasetMeta(args.index);
+    const point = meta.data[qIdx];
+    if (!point || point.skip) return;
+
     const ctx = chart.ctx;
+    const x = point.x;
+    const y = point.y;
 
-    chart.data.datasets.forEach((ds, i) => {
-      if (!ds._isInactive || !ds._activeUntil) return;
-      if (!chart.isDatasetVisible(i)) return;
+    const r = 6;
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.fillStyle = "#1a1d27";
+    ctx.fill();
+    ctx.strokeStyle = INACTIVE_COLOR;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
 
-      const qIdx = TIME_LABELS.indexOf(ds._activeUntil);
-      if (qIdx < 0) return;
-
-      // Skip if no data at this point (null value = no marker to draw)
-      if (ds.data[qIdx] == null) return;
-
-      const meta = chart.getDatasetMeta(i);
-      const point = meta.data[qIdx];
-      if (!point || point.skip) return;
-
-      const x = point.x;
-      const y = point.y;
-
-      // Draw a small circle with an x
-      const r = 6;
-      ctx.save();
-      ctx.beginPath();
-      ctx.arc(x, y, r, 0, Math.PI * 2);
-      ctx.fillStyle = "#1a1d27";
-      ctx.fill();
-      ctx.strokeStyle = INACTIVE_COLOR;
-      ctx.lineWidth = 1.5;
-      ctx.stroke();
-
-      // Draw the x
-      const xr = 2.5;
-      ctx.beginPath();
-      ctx.moveTo(x - xr, y - xr);
-      ctx.lineTo(x + xr, y + xr);
-      ctx.moveTo(x + xr, y - xr);
-      ctx.lineTo(x - xr, y + xr);
-      ctx.strokeStyle = INACTIVE_COLOR;
-      ctx.lineWidth = 1.5;
-      ctx.stroke();
-      ctx.restore();
-    });
+    const xr = 2.5;
+    ctx.beginPath();
+    ctx.moveTo(x - xr, y - xr);
+    ctx.lineTo(x + xr, y + xr);
+    ctx.moveTo(x + xr, y - xr);
+    ctx.lineTo(x - xr, y + xr);
+    ctx.strokeStyle = INACTIVE_COLOR;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+    ctx.restore();
   },
 };
 
@@ -690,6 +688,13 @@ function renderChart() {
           line += ` (${modelLabel}, ${labName})`;
         } else if (modelLabel) {
           line += ` (${modelLabel})`;
+        }
+        // OSWorld-Verified absorbed the original OSWorld timeline; mark pre-Q3 2025
+        // points so readers know that section of the line is original-OSWorld data.
+        const benchKey = context.dataset._benchKey;
+        const quarter = TIME_LABELS[context.dataIndex];
+        if (benchKey === "osworld-verified" && quarter && compareQuarters(quarter, "Q3 2025") < 0) {
+          line += ` · Original OSWorld`;
         }
         const isVerified = context.dataset._verified?.[context.dataIndex] !== false;
         const rawSource = context.dataset._source?.[context.dataIndex];

--- a/lib/analysis-prompt.js
+++ b/lib/analysis-prompt.js
@@ -43,6 +43,7 @@ Return ONLY valid JSON, no markdown fences, no extra text:
    - Benchmarks tagged [SATURATED] or [DEPRECATED] are inactive. Do NOT discuss them in frontier or race commentary.
    - Check LAB DATA COVERAGE: if a lab has low coverage, note it.
    - xAI released Grok 4.1 (November 2025) but it did not publish scores on any of the tracked benchmarks. If xAI data appears stale, this is why.
+   - UNSOLVED BENCHMARKS: When every lab's best score on a benchmark is below 5%, do NOT discuss leadership, relative performance, or claim a "leader" on that benchmark — score differences at that level are noise, not capability gaps. Treat as "unsolved" commentary only (e.g. "no lab has cracked X yet"). This applies to ARC-AGI-3 specifically as of 2026-Q2.
 
 === LAB NAME REFERENCE ===
 openai = OpenAI, anthropic = Anthropic, google = Google DeepMind, xai = xAI, chinese = Chinese Leaders`;

--- a/lib/config.js
+++ b/lib/config.js
@@ -66,6 +66,20 @@ const BENCHMARK_META = {
     link: "https://epoch.ai/frontiermath",
     status: "active",
   },
+  "osworld-verified": {
+    name: "OSWorld-Verified",
+    description: "Computer-use benchmark: an AI agent operates a real desktop environment to complete multi-step tasks across applications. Treats the original OSWorld (2024) and the OSWorld-Verified relaunch (July 2025) as one timeline; the relaunch fixed grading and infrastructure issues but Anthropic publicly confirms scores remain comparable. Verified historical scores from Epoch AI. Supplemented with unverified model card scores from the labs to show the latest releases (shown with hollow dots). Currently reported by Anthropic, OpenAI, and Chinese labs only; Google, xAI, and Meta have not published results. Scores may reflect different agent scaffolds (15-, 50-, or 100-step) — the chart shows the best score achieved per quarter.",
+    category: "Agentic",
+    link: "https://os-world.github.io/",
+    status: "active",
+  },
+  "arc-agi-3": {
+    name: "ARC-AGI-3",
+    description: "Successor to ARC-AGI-2, released March 2026 as part of ARC Prize 2026. Designed to be far harder than ARC-AGI-2: as of Q2 2026 no frontier model exceeds 1%. The flat line near zero is the signal — this benchmark exists to track when (and which lab) first cracks it. Scores from the official ARC Prize leaderboard; only first-party model submissions are included.",
+    category: "Reasoning",
+    link: "https://arcprize.org/",
+    status: "active",
+  },
   // ─── Inactive benchmarks ───
   "humaneval": {
     name: "HumanEval",

--- a/lib/config.js
+++ b/lib/config.js
@@ -36,6 +36,13 @@ const BENCHMARK_META = {
     link: "https://arcprize.org/",
     status: "active",
   },
+  "arc-agi-3": {
+    name: "ARC-AGI-3",
+    description: "Successor to ARC-AGI-2, released March 2026 as part of ARC Prize 2026. Designed to be far harder than ARC-AGI-2: as of Q2 2026 no frontier model exceeds 1%. The flat line near zero is the signal — this benchmark exists to track when (and which lab) first cracks it. Scores from the official ARC Prize leaderboard; only first-party model submissions are included.",
+    category: "Reasoning",
+    link: "https://arcprize.org/",
+    status: "active",
+  },
   "hle": {
     name: "Humanity's Last Exam",
     description: "A collaboration of 3,000+ experts across 100+ subjects, designed to be the hardest public benchmark. Released January 2025. Verified scores come from Artificial Analysis's independent evaluations. These are supplemented with unverified model card scores from the labs, to show the latest model releases (shown with hollow dots).",
@@ -71,13 +78,6 @@ const BENCHMARK_META = {
     description: "Computer-use benchmark: an AI agent operates a real desktop environment to complete multi-step tasks across applications. Treats the original OSWorld (2024) and the OSWorld-Verified relaunch (July 2025) as one timeline; the relaunch fixed grading and infrastructure issues but Anthropic publicly confirms scores remain comparable. Verified historical scores from Epoch AI. Supplemented with unverified model card scores from the labs to show the latest releases (shown with hollow dots). Currently reported by Anthropic, OpenAI, and Chinese labs only; Google, xAI, and Meta have not published results. Scores may reflect different agent scaffolds (15-, 50-, or 100-step) — the chart shows the best score achieved per quarter.",
     category: "Agentic",
     link: "https://os-world.github.io/",
-    status: "active",
-  },
-  "arc-agi-3": {
-    name: "ARC-AGI-3",
-    description: "Successor to ARC-AGI-2, released March 2026 as part of ARC Prize 2026. Designed to be far harder than ARC-AGI-2: as of Q2 2026 no frontier model exceeds 1%. The flat line near zero is the signal — this benchmark exists to track when (and which lab) first cracks it. Scores from the official ARC Prize leaderboard; only first-party model submissions are included.",
-    category: "Reasoning",
-    link: "https://arcprize.org/",
     status: "active",
   },
   // ─── Inactive benchmarks ───

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -76,10 +76,22 @@ const MODEL_LAB_PATTERNS = [
   [/doubao/i,        "chinese"],
 ];
 
-// ARC Prize: start-anchored version to reject third-party scaffolds
-const ARC_LAB_PATTERNS = MODEL_LAB_PATTERNS.map(([re, lab]) => [
-  new RegExp("^" + re.source, re.flags), lab,
-]);
+// ARC Prize: start-anchored version to reject third-party scaffolds.
+// Also accepts ARC's v3 canonical "<lab>-<model>" naming (e.g. "anthropic-opus-4-7-high").
+const ARC_LAB_PATTERNS = [
+  ...MODEL_LAB_PATTERNS.map(([re, lab]) => [
+    new RegExp("^" + re.source, re.flags), lab,
+  ]),
+  [/^anthropic-/i,  "anthropic"],
+  [/^openai-/i,     "openai"],
+  [/^google-/i,     "google"],
+  [/^xai-/i,        "xai"],
+  [/^deepseek-/i,   "chinese"],
+  [/^qwen-/i,       "chinese"],
+  [/^moonshotai-/i, "chinese"],
+  [/^minimaxai-/i,  "chinese"],
+  [/^zai-/i,        "chinese"],
+];
 
 function arcModelIdToLab(modelId) {
   for (const [pattern, lab] of ARC_LAB_PATTERNS) {

--- a/scripts/update-data.js
+++ b/scripts/update-data.js
@@ -61,10 +61,12 @@ function quarterMidDate(quarter) {
 // Earliest valid quarter per benchmark (scores before this are nulled out).
 // Prevents retroactive evaluations from appearing before a benchmark existed.
 const BENCHMARK_START_QUARTER = {
-  "hle":           "Q1 2025",  // Released January 2025
-  "gpqa":          "Q4 2023",  // Published November 2023
-  "arc-agi-2":     "Q1 2025",  // Released as part of ARC Prize 2025
-  "swe-bench-pro": "Q3 2025",  // Scale AI SEAL leaderboard launched
+  "hle":              "Q1 2025",  // Released January 2025
+  "gpqa":             "Q4 2023",  // Published November 2023
+  "arc-agi-2":        "Q1 2025",  // Released as part of ARC Prize 2025
+  "arc-agi-3":        "Q1 2026",  // Released as part of ARC Prize 2026
+  "swe-bench-pro":    "Q3 2025",  // Scale AI SEAL leaderboard launched
+  "osworld-verified": "Q3 2024",  // Original OSWorld launched Q2 2024; first frontier-lab scores Q3 2024
 };
 
 // Cost of Intelligence: benchmarks with price thresholds
@@ -82,6 +84,7 @@ const EPOCH_BENCHMARK_FILES = {
   "swe_bench_verified.csv":       { key: "swe-bench-verified", scoreCol: "mean_score" },
   "frontiermath.csv":             { key: "frontiermath", scoreCol: "mean_score" },
   "math_level_5.csv":             { key: "math-l5",      scoreCol: "mean_score" },
+  "os_world_external.csv":        { key: "osworld-verified", scoreCol: "Score" },
 };
 
 // Source-level abort thresholds. If a fetcher returns fewer rows than its threshold,
@@ -425,6 +428,7 @@ async function fetchARCPrize() {
   const datasetMap = {
     "v1_Semi_Private": "arc-agi-1",
     "v2_Semi_Private": "arc-agi-2",
+    "v3_Semi_Private": "arc-agi-3",
   };
 
   for (const entry of evaluations) {
@@ -858,7 +862,7 @@ async function main() {
   }
 
   // Automated benchmarks managed by this script. Manual seeds (humaneval) are excluded.
-  const automatedBenchmarks = ["swe-bench-verified", "arc-agi-1", "arc-agi-2", "hle", "gpqa", "aime", "frontiermath", "math-l5", "swe-bench-pro"];
+  const automatedBenchmarks = ["swe-bench-verified", "arc-agi-1", "arc-agi-2", "arc-agi-3", "hle", "gpqa", "aime", "frontiermath", "math-l5", "swe-bench-pro", "osworld-verified"];
 
   // Compute cumulative best per (benchmark, lab) and build upsert rows
   const allRows = [];

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -84,15 +84,27 @@ describe("isBenchmarkActive", () => {
 
 describe("BENCHMARK_META", () => {
   const expectedKeys = [
-    "gpqa", "arc-agi-2", "hle", "swe-bench-pro", "aime", "frontiermath",
+    "gpqa", "arc-agi-2", "arc-agi-3", "hle", "swe-bench-pro", "aime", "frontiermath",
+    "osworld-verified",
     "humaneval", "arc-agi-1", "swe-bench-verified", "math-l5",
   ];
 
-  it("has all 10 expected benchmark keys", () => {
+  it("has all 12 expected benchmark keys", () => {
     for (const key of expectedKeys) {
       expect(BENCHMARK_META).toHaveProperty(key);
     }
-    expect(Object.keys(BENCHMARK_META)).toHaveLength(10);
+    expect(Object.keys(BENCHMARK_META)).toHaveLength(12);
+  });
+
+  it("arc-agi-3 is active and in Reasoning category", () => {
+    expect(BENCHMARK_META["arc-agi-3"].status).toBe("active");
+    expect(BENCHMARK_META["arc-agi-3"].category).toBe("Reasoning");
+  });
+
+  it("osworld-verified is active and explicitly notes lab-coverage gaps in its description", () => {
+    expect(BENCHMARK_META["osworld-verified"].status).toBe("active");
+    // Methodology must disclose missing labs so users don't read silence as poor performance.
+    expect(BENCHMARK_META["osworld-verified"].description).toMatch(/Google.*xAI.*Meta|xAI.*Meta.*Google|Meta.*Google.*xAI/);
   });
 
   it("each benchmark has required fields", () => {

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -142,6 +142,14 @@ describe("arcModelIdToLab", () => {
     expect(arcModelIdToLab("llama-3-70b")).toBeNull();
     expect(arcModelIdToLab("")).toBeNull();
   });
+
+  it("matches ARC v3 canonical lab-prefix naming", () => {
+    // ARC-AGI-3 leaderboard uses "<lab>-<model>-<version>-<detail>" format.
+    expect(arcModelIdToLab("anthropic-opus-4-7-high")).toBe("anthropic");
+    expect(arcModelIdToLab("openai-gpt-5-5-2026-04-23-high")).toBe("openai");
+    expect(arcModelIdToLab("google-gemini-3-1-pro-preview")).toBe("google");
+    expect(arcModelIdToLab("xai-grok-4-20-beta-0309-reasoning")).toBe("xai");
+  });
 });
 
 // ─── modelNameToLab ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Active benchmark count goes from 4 → 6, opening two new capability dimensions on the chart:

- **ARC-AGI-3** — reasoning frontier (currently unsolved, all labs <0.6%). The flat line near zero is the signal: this benchmark tracks when and which lab first cracks it. Plumbed in via the existing ARC Prize fetcher (just extends the datasetMap).
- **OSWorld-Verified** — computer use (operating a desktop / GUI to complete multi-step tasks). New capability category the site didn't previously measure. Verified data from Epoch CSV, supplemented with unverified model card scores already in `benchmark_raw`.

GDPval was evaluated alongside these two and deferred to the "non-percentage scoring benchmarks" TASKS.md backlog item — see context section in the plan file. AA's panel publishes Elo only, OpenAI's panel publishes wins+ties %, and there's no clean way to merge those on a 0-100% axis without misleading the non-OpenAI frontier story.

## Key implementation notes

- **ARC v3 naming change**: ARC Prize switched the v3 leaderboard to `<lab>-<model>` modelId format (e.g. `anthropic-opus-4-7-high`) instead of the v1/v2 `Claude 3.7` style. Caught during the first pipeline run when arc-agi-3 came back with 0 rows attributed. Fixed by extending `ARC_LAB_PATTERNS` in `lib/pipeline.js` to accept the lab-prefix form alongside the existing model-family patterns. The patterns remain start-anchored, so third-party scaffolds are still rejected.

- **OSWorld lab coverage gap**: only Anthropic, OpenAI, and Chinese labs have OSWorld-Verified scores in either Epoch or model card data. Google, xAI, and Meta have not published results. The benchmark description in `lib/config.js` explicitly discloses this so users don't read absent lines as poor performance. A new test asserts this disclosure stays in place.

- **Sub-5% safeguard for LLM analysis**: `lib/analysis-prompt.js` gets a new rule telling the model not to claim leadership on benchmarks where every lab scores under 5%. Without this the LLM would happily narrate "Anthropic leads ARC-AGI-3 at 0.51%" — score differences at that level are noise. Verified empirically: the regenerated `last-3-months` analysis correctly says "first on... ARC-AGI-3 (though ARC-AGI-3 remains unsolved at 0.5%)".

- **OSWorld scaffold variants** (15/50/100-step): all variants get ingested; `computeCumulativeBest` picks the highest score per quarter, which is consistent with the chart's "best achievable at this time" framing. Methodology copy documents this caveat.

## Test plan

- [x] `npm test` — 229 passes (1 new for v3 lab-prefix matching, 2 new for new BENCHMARK_META entries)
- [x] `node scripts/update-data.js` ingested successfully: ARC-AGI-3 6 raw rows / 5 cumulative-best non-null rows / 4 labs; OSWorld-Verified 20 raw rows / 19 cumulative-best non-null rows / 3 labs
- [x] `node scripts/generate-analyses.js` ran clean; `last-3-months` race commentary correctly hedges ARC-AGI-3 as unsolved and acknowledges xAI's data gap on OSWorld
- [x] Source health: all 4 verified sources passed threshold checks (artificialanalysis 571, swebench 115, arcprize 271, epoch 579)
- [ ] **Visual QA needed** — please load the site and click both new benchmark tabs. Specifically:
  - ARC-AGI-3 line should hug 0% baseline with no rendering glitches; hover tooltips should show actual % + model name
  - OSWorld-Verified should render Anthropic/OpenAI/Chinese lines; Google/xAI lines should simply be absent (no error)
  - Methodology accordion for both should read correctly
  - Lab Race tab should not artificially penalize labs missing from OSWorld-Verified
  - Export button: check legend doesn't truncate at 6 active pills
  - Mobile: 6 pills wrap cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)