### PR TITLE
Reframe Frontier chart legend around 6-capability taxonomy

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,6 +163,17 @@ document.addEventListener("DOMContentLoaded", async () => {
       applyDateRange();
       fetchAnalysis(currentDateRange);
     });
+
+    // Re-render the legend on viewport changes so the desktop ↔ mobile layout
+    // switch happens dynamically (browser zoom changes window.innerWidth, so
+    // this also handles 400%+ zoom levels that cross the MOBILE_BREAKPOINT).
+    let legendResizeTimer = null;
+    window.addEventListener("resize", () => {
+      if (legendResizeTimer) clearTimeout(legendResizeTimer);
+      legendResizeTimer = setTimeout(() => {
+        if (chart) renderCustomLegend();
+      }, 150);
+    });
   } catch (err) {
     console.error("Failed to load data:", err);
     showError("Failed to load benchmark data. Please try refreshing the page.");
@@ -841,8 +852,8 @@ function renderChart() {
 function renderCustomLegend() {
   const container = document.getElementById("chartLegend");
   container.innerHTML = "";
-  // Always strip the frontier-grid class so it doesn't leak into race/cost modes.
-  container.classList.remove("frontier-grid");
+  // Always strip mode-specific classes so they don't leak across mode switches.
+  container.classList.remove("frontier-grid", "frontier-mobile");
 
   if (!chart) return;
 
@@ -861,11 +872,49 @@ function renderCustomLegend() {
   const isMobile = window.innerWidth <= MOBILE_BREAKPOINT;
 
   // Frontier mode on desktop: capability-grouped 6-column grid.
-  // Frontier on mobile + race/cost modes: original flat-list layout.
+  // Frontier on mobile: condensed capability-pill row (one pill per capability,
+  // text coloured by capability so the colour cue is preserved).
+  // Race/cost modes (any size): original flat-list layout.
   if (currentMode === "frontier" && !isMobile) {
     renderFrontierGrid(container, activeItems, inactiveItems);
+  } else if (currentMode === "frontier" && isMobile) {
+    renderFrontierMobile(container, activeItems);
   } else {
     renderFlatLegend(container, activeItems, inactiveItems, isMobile);
+  }
+}
+
+// Mobile-only: a flat row of capability pills. Each pill is interactive —
+// clicking isolates the chart to that capability's active benchmark, matching
+// the desktop "click a benchmark name to isolate" interaction model.
+function renderFrontierMobile(container, activeItems) {
+  container.classList.add("frontier-mobile");
+  const grouped = groupDatasetsByCapability(activeItems, []);
+
+  for (const cap of CAPABILITIES) {
+    const items = grouped[cap].active;
+    if (items.length === 0) continue;
+    const { idx } = items[0];
+
+    const btn = document.createElement("button");
+    btn.className = "legend-cap-pill";
+    if (!chart.isDatasetVisible(idx)) btn.classList.add("hidden");
+    btn.textContent = cap;
+    btn.title = cap;
+
+    const capColor = CAPABILITY_COLORS[cap];
+    if (capColor) btn.style.color = lightenHex(capColor, 0.45);
+
+    btn.addEventListener("click", () => {
+      if (isolatedCapability !== null) {
+        isolatedCapability = null;
+        endpointLabelTargets.clear();
+      }
+      handleLegendClick(idx);
+      renderCustomLegend();
+    });
+
+    container.appendChild(btn);
   }
 }
 
@@ -954,6 +1003,10 @@ function renderCapabilityHeader(capName) {
   const text = document.createElement("span");
   text.className = "legend-cap-header-text";
   text.textContent = capName;
+  // Native browser tooltip exposes the full name when the column is narrow
+  // enough that text-overflow: ellipsis kicks in (e.g. "Novel Problem Solving"
+  // at lower zoom levels).
+  text.title = capName;
   const capColor = CAPABILITY_COLORS[capName];
   if (capColor) text.style.color = lightenHex(capColor, 0.45);
   header.appendChild(text);

--- a/app.js
+++ b/app.js
@@ -1055,6 +1055,13 @@ function highlightCapabilityDefeated(capName, inactiveItems) {
   if (highlightedCapability !== null) unhighlightCapabilityDefeated();
   highlightedCapability = capName;
 
+  // If a different capability is currently click-isolated, the other capability's
+  // datasets aren't visible anyway — skip the chart-visual updates so we don't
+  // stomp on the isolated capability's endpoint labels. The tooltip still shows.
+  if (isolatedCapability !== null && isolatedCapability !== capName) {
+    return;
+  }
+
   inactiveItems.forEach(({ ds }) => applyActiveStyle(ds));
 
   const color = CAPABILITY_COLORS[capName] || INACTIVE_COLOR;

--- a/app.js
+++ b/app.js
@@ -127,11 +127,11 @@ function updateCitationLine() {
   if (!el) return;
   const sources = getVisibleSources();
   el.innerHTML =
-    `<span>Source: ${sources.join(", ")}</span>` +
     `<button class="chart-action-btn" id="citationInfoBtn" title="View methodology">` +
     `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">` +
     `<circle cx="8" cy="8" r="6.25"/><path d="M8 7v4"/><circle cx="8" cy="5" r="0.5" fill="currentColor" stroke="none"/>` +
-    `</svg></button>`;
+    `</svg></button>` +
+    `<span>Source: ${sources.join(", ")}</span>`;
   document.getElementById("citationInfoBtn").addEventListener("click", () => {
     const target = document.getElementById("methodologySection") || document.getElementById("infoCard");
     if (target) target.scrollIntoView({ behavior: "smooth" });
@@ -257,18 +257,13 @@ function renderLabPills(container) {
   });
   container.appendChild(allBtn);
 
-  // One pill per lab
+  // One pill per lab. The coloured dot was removed — lab colours only matter
+  // in the race-mode chart; in frontier mode they're visual noise on the filter.
   for (const [key, lab] of Object.entries(LABS)) {
     const btn = document.createElement("button");
     btn.className = `filter-pill${key === selectedLab ? " active" : ""}`;
     btn.dataset.key = key;
-
-    const dot = document.createElement("span");
-    dot.className = "pill-dot";
-    dot.style.backgroundColor = lab.color;
-
-    btn.appendChild(dot);
-    btn.appendChild(document.createTextNode(lab.name));
+    btn.textContent = lab.name;
 
     btn.addEventListener("click", () => {
       selectedLab = key;
@@ -914,6 +909,21 @@ function renderFrontierGrid(container, activeItems, inactiveItems) {
   }
 }
 
+// Blend a hex colour with white by `mix` proportion (0-1). Used to derive the
+// lighter "header" hue from the saturated capability line colour — a 0.45 mix
+// gives a pastel header that reads as the capability without competing
+// with the white-on-dark active benchmark name below it.
+function lightenHex(hex, mix) {
+  const c = hex.replace("#", "");
+  const r = parseInt(c.slice(0, 2), 16);
+  const g = parseInt(c.slice(2, 4), 16);
+  const b = parseInt(c.slice(4, 6), 16);
+  const nr = Math.round(r + (255 - r) * mix);
+  const ng = Math.round(g + (255 - g) * mix);
+  const nb = Math.round(b + (255 - b) * mix);
+  return "#" + [nr, ng, nb].map(v => v.toString(16).padStart(2, "0")).join("");
+}
+
 function renderFlatLegend(container, activeItems, inactiveItems, isMobile) {
   activeItems.forEach(({ ds, idx }) => {
     container.appendChild(createLegendButton(ds, idx, false));
@@ -940,13 +950,13 @@ function renderFlatLegend(container, activeItems, inactiveItems, isMobile) {
 function renderCapabilityHeader(capName) {
   const header = document.createElement("div");
   header.className = "legend-cap-header";
-
-  const dot = document.createElement("span");
-  dot.className = "legend-dot";
-  dot.style.backgroundColor = CAPABILITY_COLORS[capName] || "#6c9eff";
-  header.appendChild(dot);
-
-  header.appendChild(document.createTextNode(capName));
+  // Text in a span so text-overflow: ellipsis works inside the flex layout.
+  const text = document.createElement("span");
+  text.className = "legend-cap-header-text";
+  text.textContent = capName;
+  const capColor = CAPABILITY_COLORS[capName];
+  if (capColor) text.style.color = lightenHex(capColor, 0.45);
+  header.appendChild(text);
   return header;
 }
 
@@ -1391,41 +1401,62 @@ function renderInfoArea() {
       `;
     }
   } else {
+    // Group benchmarks by capability in CAPABILITIES order. Within each
+    // capability: active first, then inactive (mirrors the legend's
+    // header \u2192 active \u2192 "N defeated" structure).
+    const benchKeysByCapability = {};
+    for (const cap of CAPABILITIES) benchKeysByCapability[cap] = { active: [], inactive: [] };
     for (const [key, bench] of Object.entries(BENCHMARKS)) {
-      const isOpen = false;
-      const isInactive = !isBenchmarkActive(key, filterEnd);
       const meta = BENCHMARK_META[key];
-      const color = CAPABILITY_COLORS[meta?.capability] || INACTIVE_COLOR;
+      if (!meta || !benchKeysByCapability[meta.capability]) continue;
+      const isInactive = !isBenchmarkActive(key, filterEnd);
+      benchKeysByCapability[meta.capability][isInactive ? "inactive" : "active"].push(key);
+    }
 
-      // Status badge
-      let statusBadge = "";
-      if (isInactive && meta.status === "deprecated") {
-        statusBadge = `<span class="status-badge deprecated">Deprecated ${meta.activeUntil}</span>`;
-      } else if (isInactive && meta.status === "saturated") {
-        statusBadge = `<span class="status-badge saturated">Saturated ${meta.activeUntil}</span>`;
-      }
+    for (const cap of CAPABILITIES) {
+      const group = benchKeysByCapability[cap];
+      const orderedKeys = [...group.active, ...group.inactive];
+      for (const key of orderedKeys) {
+        const bench = BENCHMARKS[key];
+        const isOpen = false;
+        const isInactive = !isBenchmarkActive(key, filterEnd);
+        const meta = BENCHMARK_META[key];
+        const capColor = CAPABILITY_COLORS[meta?.capability] || INACTIVE_COLOR;
+        // Capability label always reflects the capability, regardless of lifecycle.
+        const badgeColor = lightenHex(capColor, 0.45);
+        // Dot mirrors the chart line colour \u2014 grey for inactive, capability colour for active.
+        const dotColor = isInactive ? INACTIVE_COLOR : capColor;
 
-      // Description with inactive reason
-      let description = bench.description;
-      if (isInactive && meta.inactiveReason) {
-        description += ` <em style="color:var(--text-muted);">${meta.inactiveReason}.</em>`;
-      }
+        // Status badge
+        let statusBadge = "";
+        if (isInactive && meta.status === "deprecated") {
+          statusBadge = `<span class="status-badge deprecated">Deprecated ${meta.activeUntil}</span>`;
+        } else if (isInactive && meta.status === "saturated") {
+          statusBadge = `<span class="status-badge saturated">Saturated ${meta.activeUntil}</span>`;
+        }
 
-      html += `
-        <div class="benchmark-item" data-bench="${key}">
-          <button class="benchmark-item-header" aria-expanded="${isOpen}">
-            <span class="pill-dot" style="background-color: ${isInactive ? INACTIVE_COLOR : color}"></span>
-            <span class="benchmark-item-name">${bench.name}</span>
-            <span class="category-badge">${bench.capability}</span>
-            ${statusBadge}
-            <span class="expand-icon">${isOpen ? "\u2212" : "+"}</span>
-          </button>
-          <div class="benchmark-item-detail"${isOpen ? "" : " hidden"}>
-            <p>${description}</p>
-            <a href="${bench.link}" target="_blank" rel="noopener">Learn more &rarr;</a>
+        // Description with inactive reason
+        let description = bench.description;
+        if (isInactive && meta.inactiveReason) {
+          description += ` <em style="color:var(--text-muted);">${meta.inactiveReason}.</em>`;
+        }
+
+        html += `
+          <div class="benchmark-item" data-bench="${key}">
+            <button class="benchmark-item-header" aria-expanded="${isOpen}">
+              <span class="pill-dot" style="background-color: ${dotColor}"></span>
+              <span class="benchmark-item-name">${bench.name}</span>
+              <span class="category-badge" style="color: ${badgeColor}; background: transparent">${bench.capability}</span>
+              ${statusBadge}
+              <span class="expand-icon">${isOpen ? "\u2212" : "+"}</span>
+            </button>
+            <div class="benchmark-item-detail"${isOpen ? "" : " hidden"}>
+              <p>${description}</p>
+              <a href="${bench.link}" target="_blank" rel="noopener">Learn more &rarr;</a>
+            </div>
           </div>
-        </div>
-      `;
+        `;
+      }
     }
   }
 
@@ -1770,27 +1801,24 @@ function buildExportCanvas() {
     for (let i = 0; i < columns.length; i++) {
       const col = columns[i];
       const colX = pad + i * colW;
-      const textMaxW = colW - colPadR - dotR * 2 - dotTextGap;
+      const colTextMaxW = colW - colPadR;
+      const capColor = CAPABILITY_COLORS[col.cap] || "#6c9eff";
+
       let rowY = pad + rowH * 0.6;
 
-      // Capability header: dot + small-caps label
-      const capColor = CAPABILITY_COLORS[col.cap] || "#6c9eff";
-      ctx.beginPath();
-      ctx.arc(colX + dotR, rowY, dotR, 0, Math.PI * 2);
-      ctx.fillStyle = capColor;
-      ctx.fill();
-      ctx.font = `bold ${smallFontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
-      ctx.fillStyle = "#808690";
+      // Capability header: uppercase, in a lightened version of the capability colour
+      ctx.font = `700 ${smallFontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+      ctx.fillStyle = lightenHex(capColor, 0.45);
       ctx.textAlign = "left";
-      const headerLabel = ellipsize(col.cap.toUpperCase(), textMaxW);
-      ctx.fillText(headerLabel, colX + dotR * 2 + dotTextGap, rowY + smallFontSize * 0.35);
+      const headerLabel = ellipsize(col.cap.toUpperCase(), colTextMaxW);
+      ctx.fillText(headerLabel, colX, rowY + smallFontSize * 0.35);
       rowY += rowH;
 
-      // Active benchmarks: capability-coloured text (matches chart line colour)
+      // Active benchmark name(s)
       ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
       for (const { ds } of col.active) {
         ctx.fillStyle = "#d4d6dc";
-        ctx.fillText(ellipsize(ds.label, textMaxW + dotR * 2 + dotTextGap), colX, rowY + fontSize * 0.35);
+        ctx.fillText(ellipsize(ds.label, colTextMaxW), colX, rowY + fontSize * 0.35);
         rowY += rowH;
       }
 

--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ const BENCHMARK_SOURCE_MAP = {
   "frontiermath":  "Epoch AI",
   "math-l5":       "Epoch AI",
   "osworld-verified": "Epoch AI",
+  "mmmu-pro":      "Artificial Analysis",
 };
 
 const COST_SOURCE = "Artificial Analysis";
@@ -64,36 +65,26 @@ let currentDateRange = "all-time";
 let chart = null;
 let chartMode = null; // tracks which mode the chart was built for
 let isolatedIndex = null;
-let highlightedInactiveIndex = null; // currently highlighted inactive dataset
+let highlightedInactiveIndex = null; // currently highlighted inactive dataset (single-line hover)
+let highlightedCapability = null;    // capability whose defeated group is hover-highlighted
+let isolatedCapability = null;       // capability whose defeated group is click-isolated
+let endpointLabelTargets = new Map(); // dataset index → { color, label }; consumed by endpointLabelPlugin
 let cachedAnalysis = null; // parsed JSON from Supabase
 
 // Clipboard SVG icon for copy buttons
 const COPY_ICON_SVG = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5.5" y="5.5" width="8" height="8" rx="1.5"/><path d="M10.5 5.5V3.5a1.5 1.5 0 00-1.5-1.5H3.5A1.5 1.5 0 002 3.5V9a1.5 1.5 0 001.5 1.5h2"/></svg>';
 
-// Category colors for tab dots
-const CATEGORY_COLORS = {
-  Coding:    "#10b981",
-  Reasoning: "#f59e0b",
-  Knowledge: "#8b5cf6",
-  Science:   "#06b6d4",
-  Math:      "#ef4444",
-  Agentic:   "#ec4899",
-};
-
-// Distinct colors for each benchmark line in frontier mode
-const BENCHMARK_COLORS = {
-  "swe-bench-verified": "#10b981",
-  "arc-agi-1":     "#f59e0b",
-  "arc-agi-2":     "#f97316",
-  "arc-agi-3":     "#c084fc",
-  "hle":           "#8b5cf6",
-  "gpqa":          "#06b6d4",
-  "aime":          "#ef4444",
-  "swe-bench-pro": "#2dd4bf",
-  "humaneval":     "#6ee7b7",
-  "frontiermath":  "#f472b6",
-  "math-l5":       "#fb7185",
-  "osworld-verified": "#fbbf24",
+// Capability colours: the single source of truth for line + dot colour in frontier mode.
+// Within a capability, multiple lines (active + deprecated/saturated) share the same hue;
+// inactive lines render grey-dashed by default and pick up the capability colour on
+// hover/isolation. Keys must match the strings in CAPABILITIES (lib/config.js).
+const CAPABILITY_COLORS = {
+  "Coding":                "#10b981",
+  "Math":                  "#ef4444",
+  "Expert Reasoning":      "#8b5cf6",
+  "Visual Reasoning":      "#06b6d4",
+  "Computer Use":          "#ec4899",
+  "Novel Problem Solving": "#f59e0b",
 };
 
 // Colors for cost benchmarks
@@ -224,7 +215,7 @@ function renderBenchmarkPills(container) {
 
     const dot = document.createElement("span");
     dot.className = "pill-dot";
-    dot.style.backgroundColor = CATEGORY_COLORS[bench.category] || "#6c9eff";
+    dot.style.backgroundColor = CAPABILITY_COLORS[bench.capability] || "#6c9eff";
 
     btn.appendChild(dot);
     btn.appendChild(document.createTextNode(bench.name));
@@ -479,7 +470,7 @@ function buildFrontierDatasets() {
       frontierSources.push(bestSource);
     }
 
-    const color = BENCHMARK_COLORS[benchKey];
+    const color = CAPABILITY_COLORS[meta.capability];
     const baseColor = isInactive ? INACTIVE_COLOR : color;
     const pointStyle = buildPointStyleArrays(frontierVerified, baseColor);
     const ds = {
@@ -569,6 +560,90 @@ const inactivityMarkerPlugin = {
 };
 
 Chart.register(inactivityMarkerPlugin);
+
+// ─── Endpoint label plugin ───────────────────────────────────
+// Draws a small coloured label at the last data point of any dataset whose index
+// is in endpointLabelTargets. Used by the "N defeated" hover/isolate flow to name
+// each defeated line on the chart (same-colour lines need name labels to be
+// distinguishable). If two labels would vertically overlap, the later one shifts
+// down by labelH + 2px.
+const endpointLabelPlugin = {
+  id: "endpointLabel",
+  afterDatasetsDraw(chart) {
+    if (currentMode !== "frontier") return;
+    if (!endpointLabelTargets || endpointLabelTargets.size === 0) return;
+
+    const ctx = chart.ctx;
+    const fontPx = Math.max(10, chartFontSize ? chartFontSize(11) : 11);
+    ctx.save();
+    ctx.font = `600 ${fontPx}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+    ctx.textBaseline = "middle";
+
+    // Collect target screen positions first so we can resolve y-collisions.
+    const placements = [];
+    for (const [idx, cfg] of endpointLabelTargets) {
+      const ds = chart.data.datasets[idx];
+      if (!ds || !chart.isDatasetVisible(idx)) continue;
+      const meta = chart.getDatasetMeta(idx);
+      // Find the last non-null point
+      let pIdx = -1;
+      for (let i = ds.data.length - 1; i >= 0; i--) {
+        if (ds.data[i] != null) { pIdx = i; break; }
+      }
+      if (pIdx < 0) continue;
+      const point = meta.data[pIdx];
+      if (!point || point.skip) continue;
+      placements.push({ x: point.x, y: point.y, label: cfg.label, color: cfg.color });
+    }
+
+    // Resolve overlaps top-to-bottom: if labels are within labelH of each other,
+    // push the lower one further down.
+    const labelH = fontPx + 8;
+    placements.sort((a, b) => a.y - b.y);
+    for (let i = 1; i < placements.length; i++) {
+      const prev = placements[i - 1];
+      const cur = placements[i];
+      if (cur.y - prev.y < labelH) cur.y = prev.y + labelH;
+    }
+
+    const padX = 6;
+    const padY = 3;
+    for (const p of placements) {
+      const textW = ctx.measureText(p.label).width;
+      const boxW = textW + padX * 2;
+      const boxH = fontPx + padY * 2;
+      // Anchor the label so it sits just to the left of the endpoint when there's
+      // not enough room to the right (right-edge chart cases).
+      let boxX = p.x + 8;
+      if (boxX + boxW > chart.chartArea.right) boxX = p.x - boxW - 8;
+      const boxY = p.y - boxH / 2;
+
+      ctx.fillStyle = p.color + "B3"; // ~70% alpha
+      const r = 3;
+      // Rounded rect
+      ctx.beginPath();
+      ctx.moveTo(boxX + r, boxY);
+      ctx.lineTo(boxX + boxW - r, boxY);
+      ctx.quadraticCurveTo(boxX + boxW, boxY, boxX + boxW, boxY + r);
+      ctx.lineTo(boxX + boxW, boxY + boxH - r);
+      ctx.quadraticCurveTo(boxX + boxW, boxY + boxH, boxX + boxW - r, boxY + boxH);
+      ctx.lineTo(boxX + r, boxY + boxH);
+      ctx.quadraticCurveTo(boxX, boxY + boxH, boxX, boxY + boxH - r);
+      ctx.lineTo(boxX, boxY + r);
+      ctx.quadraticCurveTo(boxX, boxY, boxX + r, boxY);
+      ctx.closePath();
+      ctx.fill();
+
+      ctx.fillStyle = "#ffffff";
+      ctx.textAlign = "left";
+      ctx.fillText(p.label, boxX + padX, p.y);
+    }
+
+    ctx.restore();
+  },
+};
+
+Chart.register(endpointLabelPlugin);
 
 // Allow points to draw slightly past the chart area on the right (into layout padding)
 // so markers at the last quarter aren't clipped. Positive = allow overflow.
@@ -771,6 +846,8 @@ function renderChart() {
 function renderCustomLegend() {
   const container = document.getElementById("chartLegend");
   container.innerHTML = "";
+  // Always strip the frontier-grid class so it doesn't leak into race/cost modes.
+  container.classList.remove("frontier-grid");
 
   if (!chart) return;
 
@@ -786,14 +863,64 @@ function renderCustomLegend() {
     }
   });
 
-  // Active items
+  const isMobile = window.innerWidth <= MOBILE_BREAKPOINT;
+
+  // Frontier mode on desktop: capability-grouped 6-column grid.
+  // Frontier on mobile + race/cost modes: original flat-list layout.
+  if (currentMode === "frontier" && !isMobile) {
+    renderFrontierGrid(container, activeItems, inactiveItems);
+  } else {
+    renderFlatLegend(container, activeItems, inactiveItems, isMobile);
+  }
+}
+
+// Group datasets by their benchmark's capability, splitting active vs. inactive.
+// Returns { "Coding": { active: [{ds, idx}], inactive: [...] }, ... } seeded with
+// every entry in CAPABILITIES (so empty capabilities still get rendered as a column
+// header — currently unused but kept for taxonomy completeness).
+function groupDatasetsByCapability(activeItems, inactiveItems) {
+  const grouped = {};
+  for (const cap of CAPABILITIES) grouped[cap] = { active: [], inactive: [] };
+  const assign = (items, key) => {
+    for (const item of items) {
+      const meta = BENCHMARK_META[item.ds._benchKey];
+      const cap = meta?.capability;
+      if (cap && grouped[cap]) grouped[cap][key].push(item);
+    }
+  };
+  assign(activeItems, "active");
+  assign(inactiveItems, "inactive");
+  return grouped;
+}
+
+function renderFrontierGrid(container, activeItems, inactiveItems) {
+  container.classList.add("frontier-grid");
+  const grouped = groupDatasetsByCapability(activeItems, inactiveItems);
+
+  for (const cap of CAPABILITIES) {
+    const col = document.createElement("div");
+    col.className = "legend-column";
+    col.appendChild(renderCapabilityHeader(cap));
+
+    for (const { ds, idx } of grouped[cap].active) {
+      col.appendChild(createLegendButton(ds, idx, false));
+    }
+
+    if (grouped[cap].inactive.length > 0) {
+      col.appendChild(renderDefeatedLink(cap, grouped[cap].inactive));
+    }
+
+    container.appendChild(col);
+  }
+}
+
+function renderFlatLegend(container, activeItems, inactiveItems, isMobile) {
   activeItems.forEach(({ ds, idx }) => {
-    const btn = createLegendButton(ds, idx, false);
-    container.appendChild(btn);
+    container.appendChild(createLegendButton(ds, idx, false));
   });
 
-  // Inactive section (only in frontier mode, hidden on mobile)
-  const isMobile = window.innerWidth <= MOBILE_BREAKPOINT;
+  // Inactive section only in frontier mode (we only reach here on mobile in that case;
+  // race/cost modes never have _isInactive datasets in the current data model).
   if (inactiveItems.length > 0 && currentMode === "frontier" && !isMobile) {
     const divider = document.createElement("div");
     divider.className = "legend-divider";
@@ -805,10 +932,48 @@ function renderCustomLegend() {
     container.appendChild(label);
 
     inactiveItems.forEach(({ ds, idx }) => {
-      const btn = createLegendButton(ds, idx, true);
-      container.appendChild(btn);
+      container.appendChild(createLegendButton(ds, idx, true));
     });
   }
+}
+
+function renderCapabilityHeader(capName) {
+  const header = document.createElement("div");
+  header.className = "legend-cap-header";
+
+  const dot = document.createElement("span");
+  dot.className = "legend-dot";
+  dot.style.backgroundColor = CAPABILITY_COLORS[capName] || "#6c9eff";
+  header.appendChild(dot);
+
+  header.appendChild(document.createTextNode(capName));
+  return header;
+}
+
+function renderDefeatedLink(capName, inactiveItems) {
+  const btn = document.createElement("button");
+  btn.className = "legend-defeated-link";
+  if (isolatedCapability === capName) btn.classList.add("isolated");
+
+  const n = inactiveItems.length;
+  btn.textContent = `${n} defeated`;
+
+  btn.addEventListener("mouseenter", (e) => {
+    highlightCapabilityDefeated(capName, inactiveItems);
+    showMultiBenchmarkTooltip(inactiveItems.map(i => i.ds), e.clientX, e.clientY);
+  });
+  btn.addEventListener("mouseleave", () => {
+    unhighlightCapabilityDefeated();
+    hideInactiveTooltip();
+  });
+  btn.addEventListener("click", () => {
+    // Clear any hover highlight before toggling
+    unhighlightCapabilityDefeated();
+    toggleIsolateCapabilityDefeated(capName, inactiveItems);
+    renderCustomLegend();
+  });
+
+  return btn;
 }
 
 function createLegendButton(ds, idx, isInactive) {
@@ -826,9 +991,13 @@ function createLegendButton(ds, idx, isInactive) {
 
   // Click: isolate / restore
   btn.addEventListener("click", () => {
-    // Clear any hover highlight before toggling
+    // Clear any hover highlight + group state before toggling individual isolation
     if (highlightedInactiveIndex !== null) {
       unhighlightInactive(highlightedInactiveIndex);
+    }
+    if (isolatedCapability !== null) {
+      isolatedCapability = null;
+      endpointLabelTargets.clear();
     }
     handleLegendClick(idx);
     renderCustomLegend();
@@ -876,9 +1045,78 @@ function handleLegendClick(clickedIndex) {
   chart.update();
 }
 
+// ─── Capability defeated-group highlight + isolation ─────────
+// Hovering "N defeated" lights up all defeated lines in that capability in the
+// capability colour, paints endpoint labels at each line's last data point, and
+// shows a multi-benchmark tooltip. Click toggles full isolation (other lines hidden).
+
+function highlightCapabilityDefeated(capName, inactiveItems) {
+  if (highlightedCapability === capName) return;
+  if (highlightedCapability !== null) unhighlightCapabilityDefeated();
+  highlightedCapability = capName;
+
+  inactiveItems.forEach(({ ds }) => applyActiveStyle(ds));
+
+  const color = CAPABILITY_COLORS[capName] || INACTIVE_COLOR;
+  endpointLabelTargets.clear();
+  for (const { ds, idx } of inactiveItems) {
+    endpointLabelTargets.set(idx, { color, label: ds.label });
+  }
+  chart.update("none");
+}
+
+function unhighlightCapabilityDefeated() {
+  if (highlightedCapability === null) return;
+  highlightedCapability = null;
+  // Don't reset styles for the capability that's currently click-isolated.
+  if (isolatedCapability) {
+    // Click-isolation keeps its own coloured state; just stop drawing endpoint labels
+    // for the hover-only case (they're re-set by the isolation logic if still active).
+    return;
+  }
+  chart.data.datasets.forEach((ds) => {
+    if (ds._isInactive && chart.data.datasets.indexOf(ds) !== isolatedIndex) {
+      resetInactiveStyle(ds);
+    }
+  });
+  endpointLabelTargets.clear();
+  chart.update("none");
+}
+
+function toggleIsolateCapabilityDefeated(capName, inactiveItems) {
+  if (isolatedCapability === capName) {
+    // Restore all
+    isolatedCapability = null;
+    endpointLabelTargets.clear();
+    chart.data.datasets.forEach((ds, i) => {
+      chart.setDatasetVisibility(i, true);
+      if (ds._isInactive) resetInactiveStyle(ds);
+    });
+  } else {
+    // Isolate the group
+    isolatedCapability = capName;
+    isolatedIndex = null;
+    const keepIdx = new Set(inactiveItems.map(({ idx }) => idx));
+    chart.data.datasets.forEach((ds, i) => {
+      chart.setDatasetVisibility(i, keepIdx.has(i));
+      if (keepIdx.has(i) && ds._isInactive) {
+        applyActiveStyle(ds);
+      } else if (ds._isInactive) {
+        resetInactiveStyle(ds);
+      }
+    });
+    const color = CAPABILITY_COLORS[capName] || INACTIVE_COLOR;
+    endpointLabelTargets.clear();
+    for (const { ds, idx } of inactiveItems) {
+      endpointLabelTargets.set(idx, { color, label: ds.label });
+    }
+  }
+  chart.update();
+}
+
 // ─── Inactive line styling helpers ───────────────────────────
 function applyActiveStyle(ds) {
-  const color = BENCHMARK_COLORS[ds._benchKey];
+  const color = CAPABILITY_COLORS[BENCHMARK_META[ds._benchKey]?.capability] || ds.borderColor;
   ds.borderColor = color;
   ds.backgroundColor = color + "33";
   ds.pointHoverBackgroundColor = color;
@@ -1006,9 +1244,12 @@ function getOrCreateInactiveTooltip() {
   return inactiveTooltipEl;
 }
 
-function showInactiveTooltip(ds, clientX, clientY) {
-  const tip = getOrCreateInactiveTooltip();
+// Build one row of tooltip HTML for an inactive dataset: name + status badge + peak line.
+// Reason text intentionally omitted (peak score conveys the saturation story; deeper
+// context lives in the methodology section).
+function buildInactiveTooltipRowHtml(ds) {
   const meta = BENCHMARK_META[ds._benchKey];
+  if (!meta) return "";
 
   const statusLabel = meta.status === "deprecated" ? "Deprecated" : "Saturated";
   const statusClass = meta.status === "deprecated" ? "deprecated" : "saturated";
@@ -1029,15 +1270,12 @@ function showInactiveTooltip(ds, clientX, clientY) {
   }
 
   const labName = latestLab ? (LABS[latestLab]?.name || latestLab) : null;
-
   const safeName = escapeHtml(ds.label);
   const safeModel = latestModel ? escapeHtml(latestModel) : null;
   const safeLabName = labName ? escapeHtml(labName) : null;
 
-  let html = `<div class="inactive-tooltip-name">${safeName} <span class="status-badge ${statusClass}">${statusLabel} ${meta.activeUntil}</span></div>`;
-  if (meta.inactiveReason) {
-    html += `<div class="inactive-tooltip-reason">${escapeHtml(meta.inactiveReason)}</div>`;
-  }
+  let html = `<div class="inactive-tooltip-row">`;
+  html += `<div class="inactive-tooltip-name">${safeName} <span class="status-badge ${statusClass}">${statusLabel} ${meta.activeUntil || ""}</span></div>`;
   if (latestScore !== null) {
     html += `<div class="inactive-tooltip-score">Peak: ${latestScore.toFixed(1)}%`;
     if (safeModel && safeLabName) html += ` (${safeModel}, ${safeLabName})`;
@@ -1045,22 +1283,33 @@ function showInactiveTooltip(ds, clientX, clientY) {
     if (latestQuarter) html += ` \u2014 ${latestQuarter}`;
     html += `</div>`;
   }
+  html += `</div>`;
+  return html;
+}
 
-  tip.innerHTML = html;
+function positionTooltip(tip, clientX, clientY) {
   tip.style.display = "block";
-
-  // Position above cursor so it doesn't overlap the horizontal line
   const rect = tip.getBoundingClientRect();
   let left = clientX - rect.width / 2;
   let top = clientY - rect.height - 16;
-
-  // Keep within viewport
   if (left < 8) left = 8;
   if (left + rect.width > window.innerWidth - 8) left = window.innerWidth - rect.width - 8;
   if (top < 8) top = clientY + 20; // flip below if no room above
-
   tip.style.left = left + "px";
   tip.style.top = top + "px";
+}
+
+function showInactiveTooltip(ds, clientX, clientY) {
+  const tip = getOrCreateInactiveTooltip();
+  tip.innerHTML = buildInactiveTooltipRowHtml(ds);
+  positionTooltip(tip, clientX, clientY);
+}
+
+// Multi-benchmark tooltip used by "N defeated" hover. Stacks one row per defeated dataset.
+function showMultiBenchmarkTooltip(datasets, clientX, clientY) {
+  const tip = getOrCreateInactiveTooltip();
+  tip.innerHTML = datasets.map(buildInactiveTooltipRowHtml).join("");
+  positionTooltip(tip, clientX, clientY);
 }
 
 function hideInactiveTooltip() {
@@ -1070,6 +1319,9 @@ function hideInactiveTooltip() {
 function updateChart() {
   isolatedIndex = null;
   highlightedInactiveIndex = null;
+  isolatedCapability = null;
+  highlightedCapability = null;
+  endpointLabelTargets.clear();
   hideInactiveTooltip();
   clearChartMessage();
 
@@ -1133,10 +1385,10 @@ function renderInfoArea() {
     }
   } else {
     for (const [key, bench] of Object.entries(BENCHMARKS)) {
-      const color = BENCHMARK_COLORS[key] || INACTIVE_COLOR;
       const isOpen = false;
       const isInactive = !isBenchmarkActive(key, filterEnd);
       const meta = BENCHMARK_META[key];
+      const color = CAPABILITY_COLORS[meta?.capability] || INACTIVE_COLOR;
 
       // Status badge
       let statusBadge = "";
@@ -1157,7 +1409,7 @@ function renderInfoArea() {
           <button class="benchmark-item-header" aria-expanded="${isOpen}">
             <span class="pill-dot" style="background-color: ${isInactive ? INACTIVE_COLOR : color}"></span>
             <span class="benchmark-item-name">${bench.name}</span>
-            <span class="category-badge">${bench.category}</span>
+            <span class="category-badge">${bench.capability}</span>
             ${statusBadge}
             <span class="expand-icon">${isOpen ? "\u2212" : "+"}</span>
           </button>
@@ -1423,25 +1675,61 @@ function buildExportCanvas() {
   const scaled = (base) => Math.round(base * CHART_DPR * exportScale);
 
   const pad = scaled(16);           // outer padding around entire export
-  const rowH = scaled(30);          // height of one legend row
+  const rowH = scaled(22);          // height of one legend row inside a column
   const citationH = scaled(36);     // height of the citation footer
-  const dividerGap = scaled(6);     // gap around the active/inactive divider line
   const legendBottomPad = scaled(16); // space between legend and chart
   const fontSize = scaled(11);      // legend label font size
-  const smallFontSize = scaled(9);  // section header font size ("MAJOR BENCHMARKS ~DEFEATED")
-  const dotR = scaled(4);           // legend color dot radius
+  const smallFontSize = scaled(9);  // capability header font size
+  const dotR = scaled(4);           // capability colour dot radius
   const dotTextGap = scaled(6);     // gap between dot and label text
-  const itemGap = scaled(16);       // gap between legend items
   const citationFontSize = scaled(10); // citation footer font size
 
-  // Determine legend layout
+  // ─── Build per-capability column groups (frontier mode) or fall back to flat
+  // legend (race/cost modes). Mirrors renderCustomLegend's branching.
   const visibleDatasets = chart.data.datasets
     .map((ds, i) => ({ ds, idx: i }))
     .filter(({ idx }) => chart.isDatasetVisible(idx));
-  const activeDs = visibleDatasets.filter(({ ds }) => !ds._isInactive);
-  const inactiveDs = visibleDatasets.filter(({ ds }) => ds._isInactive);
-  const hasInactiveRow = inactiveDs.length > 0 && currentMode === "frontier";
-  const legendH = (hasInactiveRow ? rowH * 2 + dividerGap : rowH) + legendBottomPad;
+
+  const isFrontier = currentMode === "frontier";
+  let columns = []; // [{ cap, active: [{ds, idx}], defeatedCount }]
+  let flatItems = []; // race/cost fallback
+
+  if (isFrontier) {
+    const grouped = {};
+    for (const cap of CAPABILITIES) grouped[cap] = { active: [], inactive: [] };
+    for (const { ds, idx } of chart.data.datasets.map((ds, i) => ({ ds, idx: i }))) {
+      const meta = BENCHMARK_META[ds._benchKey];
+      const cap = meta?.capability;
+      if (!cap || !grouped[cap]) continue;
+      // For the export, only show defeated entries if they're currently visible
+      // (e.g., user clicked "N defeated" and the chart is showing just that group).
+      if (ds._isInactive) {
+        if (chart.isDatasetVisible(idx)) grouped[cap].inactive.push({ ds, idx });
+        else grouped[cap].inactive.push({ ds, idx, hidden: true });
+      } else if (chart.isDatasetVisible(idx)) {
+        grouped[cap].active.push({ ds, idx });
+      }
+    }
+    columns = CAPABILITIES.map(cap => ({
+      cap,
+      active: grouped[cap].active,
+      defeatedCount: grouped[cap].inactive.length,
+    }));
+  } else {
+    flatItems = visibleDatasets;
+  }
+
+  // Compute legend height: max rows per column (header + each active + optional defeated link).
+  let legendH;
+  if (isFrontier) {
+    const maxRows = columns.reduce((m, c) => {
+      const rows = 1 /* header */ + c.active.length + (c.defeatedCount > 0 ? 1 : 0);
+      return Math.max(m, rows);
+    }, 1);
+    legendH = maxRows * rowH + legendBottomPad;
+  } else {
+    legendH = rowH + legendBottomPad;
+  }
 
   const totalW = chartW + pad * 2;
   const totalH = chartH + pad + legendH + citationH;
@@ -1454,58 +1742,83 @@ function buildExportCanvas() {
   // Background
   ctx.fillStyle = "#0f1117";
   ctx.fillRect(0, 0, totalW, totalH);
-  const maxLegendX = totalW - pad;
 
-  let legendX = pad;
-  let legendY = pad + rowH * 0.6;
-
-  function drawLegendItem(ds, textColor) {
-    const isIsolated = isolatedIndex === chart.data.datasets.indexOf(ds);
-    const color = (ds._isInactive && !isIsolated) ? INACTIVE_COLOR : (BENCHMARK_COLORS[ds._benchKey] || ds.borderColor);
-    ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
-    const labelWidth = ctx.measureText(ds.label).width;
-    const itemWidth = dotR * 2 + dotTextGap + labelWidth + itemGap;
-    if (legendX + itemWidth > maxLegendX) return;
-
-    ctx.beginPath();
-    ctx.arc(legendX + dotR, legendY, dotR, 0, Math.PI * 2);
-    ctx.fillStyle = color;
-    ctx.fill();
-    legendX += dotR * 2 + dotTextGap;
-
-    ctx.fillStyle = textColor;
-    ctx.textAlign = "left";
-    ctx.fillText(ds.label, legendX, legendY + fontSize * 0.35);
-    legendX += labelWidth + itemGap;
+  // Truncate text with ellipsis to fit within maxW (manual measure + char trim).
+  function ellipsize(text, maxW) {
+    if (ctx.measureText(text).width <= maxW) return text;
+    let lo = 0, hi = text.length;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (ctx.measureText(text.slice(0, mid) + "…").width <= maxW) lo = mid;
+      else hi = mid - 1;
+    }
+    return text.slice(0, lo) + "…";
   }
 
-  // Row 1: Active items
-  for (const { ds } of activeDs) drawLegendItem(ds, "#9aa0a6");
+  if (isFrontier) {
+    const innerW = totalW - pad * 2;
+    const colW = innerW / CAPABILITIES.length;
+    const colPadR = scaled(8); // right-side breathing room inside each column
 
-  // Row 2: Defeated section (frontier mode only)
-  if (hasInactiveRow) {
-    // Divider line
-    const dividerY = pad + rowH + dividerGap * 0.5;
-    ctx.strokeStyle = "#2d3140";
-    ctx.lineWidth = CHART_DPR;
-    ctx.beginPath();
-    ctx.moveTo(pad, dividerY);
-    ctx.lineTo(totalW - pad, dividerY);
-    ctx.stroke();
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i];
+      const colX = pad + i * colW;
+      const textMaxW = colW - colPadR - dotR * 2 - dotTextGap;
+      let rowY = pad + rowH * 0.6;
 
-    // Move to row 2
-    legendX = pad;
-    legendY = pad + rowH + dividerGap + rowH * 0.6;
+      // Capability header: dot + small-caps label
+      const capColor = CAPABILITY_COLORS[col.cap] || "#6c9eff";
+      ctx.beginPath();
+      ctx.arc(colX + dotR, rowY, dotR, 0, Math.PI * 2);
+      ctx.fillStyle = capColor;
+      ctx.fill();
+      ctx.font = `bold ${smallFontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+      ctx.fillStyle = "#808690";
+      ctx.textAlign = "left";
+      const headerLabel = ellipsize(col.cap.toUpperCase(), textMaxW);
+      ctx.fillText(headerLabel, colX + dotR * 2 + dotTextGap, rowY + smallFontSize * 0.35);
+      rowY += rowH;
 
-    const sectionLabel = "MAJOR BENCHMARKS ~DEFEATED";
-    ctx.font = `bold ${smallFontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
-    const sectionWidth = ctx.measureText(sectionLabel).width + itemGap;
-    ctx.fillStyle = "#808690";
-    ctx.textAlign = "left";
-    ctx.fillText(sectionLabel, legendX, legendY + smallFontSize * 0.35);
-    legendX += sectionWidth;
+      // Active benchmarks: capability-coloured text (matches chart line colour)
+      ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+      for (const { ds } of col.active) {
+        ctx.fillStyle = "#d4d6dc";
+        ctx.fillText(ellipsize(ds.label, textMaxW + dotR * 2 + dotTextGap), colX, rowY + fontSize * 0.35);
+        rowY += rowH;
+      }
 
-    for (const { ds } of inactiveDs) drawLegendItem(ds, "#9aa0a6");
+      // Defeated link (static text in export — no interactivity)
+      if (col.defeatedCount > 0) {
+        ctx.fillStyle = "#808690";
+        ctx.fillText(`${col.defeatedCount} defeated`, colX, rowY + fontSize * 0.35);
+      }
+    }
+  } else {
+    // Flat fallback for race/cost modes
+    let legendX = pad;
+    const legendY = pad + rowH * 0.6;
+    const maxLegendX = totalW - pad;
+    const itemGap = scaled(16);
+    ctx.font = `${fontSize}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+    for (const { ds } of flatItems) {
+      const labelWidth = ctx.measureText(ds.label).width;
+      const itemWidth = dotR * 2 + dotTextGap + labelWidth + itemGap;
+      if (legendX + itemWidth > maxLegendX) break;
+
+      const benchMeta = BENCHMARK_META[ds._benchKey];
+      const capColor = benchMeta ? CAPABILITY_COLORS[benchMeta.capability] : null;
+      const dotColor = ds._isInactive ? INACTIVE_COLOR : (capColor || ds.borderColor);
+      ctx.beginPath();
+      ctx.arc(legendX + dotR, legendY, dotR, 0, Math.PI * 2);
+      ctx.fillStyle = dotColor;
+      ctx.fill();
+      legendX += dotR * 2 + dotTextGap;
+
+      ctx.fillStyle = "#9aa0a6";
+      ctx.textAlign = "left";
+      ctx.fillText(ds.label, legendX, legendY + fontSize * 0.35);
+      legendX += labelWidth + itemGap;
+    }
   }
 
   // Chart image

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,14 +16,14 @@ const LAB_KEYS = Object.keys(LABS);
 
 // ─── Benchmark metadata ──────────────────────────────────────
 
-// Descriptions, categories, links, lifecycle status.
+// Descriptions, capabilities, links, lifecycle status.
 // Active benchmarks first, then inactive (grouped for readability).
 const BENCHMARK_META = {
   // ─── Active benchmarks ───
   "gpqa": {
     name: "GPQA Diamond",
     description: "Graduate-level science questions in physics, chemistry, and biology. Domain experts achieve ~65%; non-experts perform at chance. Verified scores come from Artificial Analysis's independent evaluations. These are supplemented with unverified model card scores from the labs, to show the latest model releases (shown with hollow dots).",
-    category: "Science",
+    capability: "Expert Reasoning",
     link: "https://arxiv.org/abs/2311.12022",
     status: "saturated",
     activeUntil: "Q1 2026",
@@ -32,35 +32,37 @@ const BENCHMARK_META = {
   "arc-agi-2": {
     name: "ARC-AGI-2",
     description: "Measures novel pattern recognition and abstraction with tasks that are trivial for humans but difficult for AI. Released January 2025 as part of ARC Prize 2025. Scores from the official ARC Prize leaderboard; only first-party model submissions are included. Third-party scaffolds and wrappers are excluded.",
-    category: "Reasoning",
+    capability: "Novel Problem Solving",
     link: "https://arcprize.org/",
-    status: "active",
+    status: "deprecated",
+    activeUntil: "Q2 2026",
+    inactiveReason: "Replaced by ARC-AGI-3 as the field's primary novel-reasoning frontier (released March 2026). Top frontier scores reached 83-85% by Q2 2026 across OpenAI, Google, and Anthropic before the transition.",
   },
   "arc-agi-3": {
     name: "ARC-AGI-3",
     description: "Successor to ARC-AGI-2, released March 2026 as part of ARC Prize 2026. Designed to be far harder than ARC-AGI-2: as of Q2 2026 no frontier model exceeds 1%. The flat line near zero is the signal — this benchmark exists to track when (and which lab) first cracks it. Scores from the official ARC Prize leaderboard; only first-party model submissions are included.",
-    category: "Reasoning",
+    capability: "Novel Problem Solving",
     link: "https://arcprize.org/",
     status: "active",
   },
   "hle": {
     name: "Humanity's Last Exam",
     description: "A collaboration of 3,000+ experts across 100+ subjects, designed to be the hardest public benchmark. Released January 2025. Verified scores come from Artificial Analysis's independent evaluations. These are supplemented with unverified model card scores from the labs, to show the latest model releases (shown with hollow dots).",
-    category: "Knowledge",
+    capability: "Expert Reasoning",
     link: "https://lastexam.ai/",
     status: "active",
   },
   "swe-bench-pro": {
     name: "SWE-bench Pro (Public)",
     description: "Long-horizon software engineering tasks in real open-source repositories. Harder than SWE-bench Verified, with multi-file changes, longer reasoning chains, and fixes for bugs in Verified's question set. Scores from the official Scale AI SEAL public leaderboard. These are supplemented with unverified model card scores from the labs, to show the latest model releases (shown with hollow dots).",
-    category: "Coding",
+    capability: "Coding",
     link: "https://scale.com/leaderboard",
     status: "active",
   },
   "aime": {
     name: "AIME (OTIS Mock)",
     description: "Competition-level math problems modeled on the American Invitational Mathematics Examination. Uses the OTIS Mock AIME 2024\u20132025 variant tracked by Epoch AI, which is harder than the standard AIME and less susceptible to data contamination.",
-    category: "Math",
+    capability: "Math",
     link: "https://epoch.ai/data/math-benchmark-scores",
     status: "saturated",
     activeUntil: "Q2 2026",
@@ -69,22 +71,29 @@ const BENCHMARK_META = {
   "frontiermath": {
     name: "FrontierMath",
     description: "Research-level mathematics problems created by professional mathematicians. Goes beyond competition math (AIME) into open research questions requiring deep mathematical reasoning across multiple fields. Independently evaluated by Epoch AI.",
-    category: "Math",
+    capability: "Math",
     link: "https://epoch.ai/frontiermath",
     status: "active",
   },
   "osworld-verified": {
     name: "OSWorld-Verified",
     description: "Computer-use benchmark: an AI agent operates a real desktop environment to complete multi-step tasks across applications. Treats the original OSWorld (2024) and the OSWorld-Verified relaunch (July 2025) as one timeline; the relaunch fixed grading and infrastructure issues but Anthropic publicly confirms scores remain comparable. Verified historical scores from Epoch AI. Supplemented with unverified model card scores from the labs to show the latest releases (shown with hollow dots). Currently reported by Anthropic, OpenAI, and Chinese labs only; Google, xAI, and Meta have not published results. Scores may reflect different agent scaffolds (15-, 50-, or 100-step) — the chart shows the best score achieved per quarter.",
-    category: "Agentic",
+    capability: "Computer Use",
     link: "https://os-world.github.io/",
+    status: "active",
+  },
+  "mmmu-pro": {
+    name: "MMMU-Pro",
+    description: "Multimodal benchmark testing visual reasoning across charts, diagrams, and scientific figures. Harder than the original MMMU, with image-based questions requiring genuine reasoning rather than text-only shortcuts. Verified scores come from Artificial Analysis's evaluation page (scraped from the embedded data; not exposed on the AA models API). Supplemented with unverified model card scores from the labs to show the latest model releases (shown with hollow dots).",
+    capability: "Visual Reasoning",
+    link: "https://mmmu-benchmark.github.io/",
     status: "active",
   },
   // ─── Inactive benchmarks ───
   "humaneval": {
     name: "HumanEval",
     description: "164 hand-written Python programming problems testing code generation from docstrings. Created by OpenAI in 2021, it became the standard coding benchmark. Scores compiled from published papers and technical reports.",
-    category: "Coding",
+    capability: "Coding",
     link: "https://arxiv.org/abs/2107.03374",
     status: "saturated",
     activeUntil: "Q4 2024",
@@ -93,7 +102,7 @@ const BENCHMARK_META = {
   "arc-agi-1": {
     name: "ARC-AGI-1",
     description: "The original ARC Prize benchmark for novel pattern recognition and abstraction. Tasks that are trivial for humans but difficult for AI. Scores from the official ARC Prize leaderboard; only first-party model submissions are included.",
-    category: "Reasoning",
+    capability: "Novel Problem Solving",
     link: "https://arcprize.org/",
     status: "deprecated",
     activeUntil: "Q1 2025",
@@ -102,7 +111,7 @@ const BENCHMARK_META = {
   "swe-bench-verified": {
     name: "SWE-bench Verified",
     description: "Real GitHub issues from popular open-source Python repositories. Models must generate working patches. Scores from the official SWE-bench Verified leaderboard. Each submission pairs a scaffold with a model; we attribute scores to the underlying model\u2019s lab. Multi-lab entries are excluded.",
-    category: "Coding",
+    capability: "Coding",
     link: "https://www.swebench.com/",
     status: "saturated",
     activeUntil: "Q3 2025",
@@ -111,13 +120,28 @@ const BENCHMARK_META = {
   "math-l5": {
     name: "MATH Level 5",
     description: "The hardest tier of the MATH benchmark: olympiad and research-competition problems requiring multi-step reasoning. Independently evaluated by Epoch AI.",
-    category: "Math",
+    capability: "Math",
     link: "https://arxiv.org/abs/2103.03874",
     status: "saturated",
     activeUntil: "Q1 2025",
     inactiveReason: "Top models score 96%+, even the hardest math tier is effectively solved",
   },
 };
+
+// ─── Capability taxonomy ─────────────────────────────────────
+
+// Canonical capability display order used by the Frontier Progress legend.
+// Adding a 7th capability? Add the string here AND a matching colour key in
+// CAPABILITY_COLORS in app.js, and verify the 6-column CSS grid layout still
+// makes sense.
+const CAPABILITIES = [
+  "Coding",
+  "Math",
+  "Expert Reasoning",
+  "Visual Reasoning",
+  "Computer Use",
+  "Novel Problem Solving",
+];
 
 // ─── Cost of Intelligence metadata ───────────────────────────
 
@@ -206,6 +230,7 @@ const _config = {
   LABS,
   LAB_KEYS,
   BENCHMARK_META,
+  CAPABILITIES,
   COST_BENCHMARK_META,
   TIME_LABELS,
   generateTimeLabels,

--- a/scripts/generate-analyses.js
+++ b/scripts/generate-analyses.js
@@ -369,7 +369,7 @@ function getDataForRange(startIdx, endIdx) {
   for (const [benchKey, bench] of Object.entries(BENCHMARKS)) {
     const meta = BENCHMARK_META[benchKey];
     const isInactive = !isBenchmarkActive(benchKey, filterEnd);
-    let header = `\n## ${bench.name} (${bench.category})`;
+    let header = `\n## ${bench.name} (${bench.capability})`;
     if (isInactive && meta.status === "saturated") {
       header += ` [SATURATED - ${meta.activeUntil}]`;
     } else if (isInactive && meta.status === "deprecated") {

--- a/scripts/update-data.js
+++ b/scripts/update-data.js
@@ -198,6 +198,39 @@ async function fetchModelCardData(supabase) {
 
 // ─── HTTP helpers ────────────────────────────────────────────
 
+/** Fetch a URL as text with optional headers. Follows redirects. */
+function fetchText(url, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const request = (reqUrl) => {
+      const urlObj = new URL(reqUrl);
+      const options = {
+        hostname: urlObj.hostname,
+        path: urlObj.pathname + urlObj.search,
+        headers: { ...headers },
+      };
+
+      https.get(options, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          request(res.headers.location);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode} from ${reqUrl}`));
+          return;
+        }
+
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          resolve(Buffer.concat(chunks).toString());
+        });
+      }).on("error", reject);
+    };
+
+    request(url);
+  });
+}
+
 /** Fetch JSON from a URL with optional headers. Follows redirects. */
 function fetchJSON(url, headers = {}) {
   return new Promise((resolve, reject) => {
@@ -266,19 +299,30 @@ function downloadFile(url) {
 
 // ─── Source 1: Artificial Analysis API (HLE + GPQA Diamond) ──
 
-async function fetchArtificialAnalysis() {
-  console.log("   [AA] Fetching Artificial Analysis API...");
+// Module-level cache so the MMMU-Pro page-scrape fetcher can reuse the models list
+// for UUID → lab/model lookup without making a second API call.
+let _aaModelsCache = null;
+
+async function fetchAAModels() {
+  if (_aaModelsCache) return _aaModelsCache;
   const response = await fetchJSON(
     "https://artificialanalysis.ai/api/v2/data/llms/models",
     { "x-api-key": AA_API_KEY }
   );
-
-  // API returns { status, prompt_options, data: [...models] }
   const models = response.data || response;
   if (!Array.isArray(models)) {
     console.warn("   [AA] WARN: Unexpected response structure, expected array in .data");
-    return [];
+    _aaModelsCache = [];
+  } else {
+    _aaModelsCache = models;
   }
+  return _aaModelsCache;
+}
+
+async function fetchArtificialAnalysis() {
+  console.log("   [AA] Fetching Artificial Analysis API...");
+  const models = await fetchAAModels();
+  if (models.length === 0) return [];
 
   const results = [];
   let skipped = 0;
@@ -321,6 +365,59 @@ async function fetchArtificialAnalysis() {
   }
 
   console.log(`   [AA] ${results.length} data points from ${models.length} models (${skipped} skipped)`);
+  return results;
+}
+
+// ─── Source 1b: Artificial Analysis page scrape (MMMU-Pro) ───
+// MMMU-Pro isn't exposed on the /api/v2/data/llms/models endpoint, but the per-evaluation
+// page embeds the same data in escaped JSON. Pattern ported from .scratch-pace-phaseA6.mjs:178-205.
+// Brittleness mitigations: unescape \\" once, require every parsed UUID to resolve in the
+// models cache (so a page-template change won't silently produce wrong-benchmark scores),
+// and the AA source-threshold check at the pipeline level catches a total scrape failure.
+
+async function fetchArtificialAnalysisMMMUPro() {
+  console.log("   [AA] Fetching MMMU-Pro page scrape...");
+  const models = await fetchAAModels();
+  if (models.length === 0) return [];
+
+  const body = await fetchText(
+    "https://artificialanalysis.ai/evaluations/mmmu-pro",
+    { "User-Agent": "Mozilla/5.0" }
+  );
+  const unesc = body.replace(/\\"/g, '"');
+  const byId = new Map(models.map(m => [m.id, m]));
+
+  const results = [];
+  let unresolvedUuids = 0;
+  for (const m of unesc.matchAll(/"mmmu_pro":([0-9.]+)/g)) {
+    const before = unesc.slice(Math.max(0, m.index - 3000), m.index);
+    const ids = [...before.matchAll(/"id":"([0-9a-f-]{36})"/g)];
+    const lastId = ids[ids.length - 1]?.[1];
+    if (!lastId) continue;
+    const a = byId.get(lastId);
+    if (!a) { unresolvedUuids++; continue; }
+
+    const lab = normalizeOrg(a.model_creator?.name);
+    if (!lab || !LAB_KEYS.includes(lab)) continue;
+    if (!a.release_date) continue;
+    const releaseDate = new Date(a.release_date);
+    if (isNaN(releaseDate.getTime())) continue;
+
+    const rawScore = parseFloat(m[1]);
+    if (isNaN(rawScore)) continue;
+
+    results.push({
+      benchmark: "mmmu-pro",
+      lab,
+      model: a.name || a.slug || "Unknown",
+      score: rawScore <= 1 ? rawScore * 100 : rawScore,
+      date: releaseDate,
+      source: "artificialanalysis",
+      verified: true,
+    });
+  }
+
+  console.log(`   [AA] MMMU-Pro: ${results.length} data points (${unresolvedUuids} unresolved UUIDs skipped)`);
   return results;
 }
 
@@ -739,10 +836,11 @@ async function main() {
     process.exit(1);
   }
 
-  // Fetch from all 4 sources in parallel
+  // Fetch from all sources in parallel
   console.log("\n1. Fetching from all sources...");
-  const [aaData, sweData, arcData, epochData, costData] = await Promise.all([
+  const [aaData, aaMMMUProData, sweData, arcData, epochData, costData] = await Promise.all([
     fetchArtificialAnalysis().catch(err => { console.error("   [AA] FAILED:", err.message); return []; }),
+    fetchArtificialAnalysisMMMUPro().catch(err => { console.error("   [AA MMMU-Pro] FAILED:", err.message); return []; }),
     fetchSWEBench().catch(err => { console.error("   [SWE] FAILED:", err.message); return []; }),
     fetchARCPrize().catch(err => { console.error("   [ARC] FAILED:", err.message); return []; }),
     fetchEpoch().catch(err => { console.error("   [Epoch] FAILED:", err.message); return []; }),
@@ -754,8 +852,10 @@ async function main() {
   // empty. Preserves last-good benchmark_scores; signals via marker + stdout sentinel.
   // The marker is written on every run (success or failure) so the orchestrator
   // can render a "Source Health" table in the issue body for ongoing trend visibility.
+  // MMMU-Pro counts fold into the AA bucket so a scrape failure surfaces against the
+  // existing AA threshold rather than requiring a new threshold key.
   const sourceCounts = {
-    artificialanalysis: aaData,
+    artificialanalysis: [...aaData, ...aaMMMUProData],
     swebench:           sweData,
     arcprize:           arcData,
     epoch:              epochData,
@@ -804,7 +904,7 @@ async function main() {
     console.log(`   Using ${MODEL_CARD_DATA.length} hardcoded model card entries (DB fallback)`);
   }
 
-  const allMerged = [...aaData, ...sweData, ...arcData, ...epochData, ...modelCardData, ...SWEBENCH_PRO_SEED];
+  const allMerged = [...aaData, ...aaMMMUProData, ...sweData, ...arcData, ...epochData, ...modelCardData, ...SWEBENCH_PRO_SEED];
   const allFiltered = filterVerifiedDuplicates(allMerged);
 
   const byBenchmark = {}; // { benchKey: { labKey: [dataPoints] } }
@@ -862,7 +962,7 @@ async function main() {
   }
 
   // Automated benchmarks managed by this script. Manual seeds (humaneval) are excluded.
-  const automatedBenchmarks = ["swe-bench-verified", "arc-agi-1", "arc-agi-2", "arc-agi-3", "hle", "gpqa", "aime", "frontiermath", "math-l5", "swe-bench-pro", "osworld-verified"];
+  const automatedBenchmarks = ["swe-bench-verified", "arc-agi-1", "arc-agi-2", "arc-agi-3", "hle", "gpqa", "aime", "frontiermath", "math-l5", "swe-bench-pro", "osworld-verified", "mmmu-pro"];
 
   // Compute cumulative best per (benchmark, lab) and build upsert rows
   const allRows = [];

--- a/styles.css
+++ b/styles.css
@@ -269,6 +269,76 @@ main {
   opacity: 1;
 }
 
+/* ─── Capability-grouped legend (frontier mode desktop only) ─── */
+
+.chart-legend.frontier-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.4rem 0.85rem;
+  align-items: start;
+  padding-right: 70px;
+}
+
+.legend-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0; /* allows ellipsis instead of overflow on narrow columns */
+}
+
+.legend-cap-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: var(--text-muted);
+  user-select: none;
+  padding: 0.1rem 0.25rem 0.2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.legend-defeated-link {
+  background: none;
+  border: none;
+  padding: 0.15rem 0.25rem;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  text-decoration: underline dotted;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+.legend-defeated-link:hover {
+  color: var(--text-secondary);
+}
+
+.legend-defeated-link.isolated {
+  color: var(--text-primary);
+  text-decoration-style: solid;
+}
+
+/* In the grid layout, individual benchmark buttons need to truncate gracefully */
+.chart-legend.frontier-grid .legend-item {
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Stacked tooltip rows for "N defeated" hover */
+.inactive-tooltip-row + .inactive-tooltip-row {
+  border-top: 1px solid var(--border);
+  margin-top: 0.4rem;
+  padding-top: 0.4rem;
+}
+
 /* Status badges for info area */
 .status-badge {
   display: inline-block;
@@ -697,6 +767,17 @@ footer {
 
   /* Legend: tighter spacing, less clearance for action buttons */
   .chart-legend { gap: 0.15rem 0.5rem; padding-right: 40px; padding-bottom: 0.5rem; }
+
+  /* Mobile falls back to the flat legend (renderFlatLegend on mobile only).
+     Strip the grid class if it somehow survives, hide capability headers and
+     defeated link as a belt-and-suspenders defence. */
+  .chart-legend.frontier-grid {
+    display: flex;
+    flex-wrap: wrap;
+    grid-template-columns: none;
+  }
+  .legend-cap-header,
+  .legend-defeated-link { display: none; }
 
   /* Smaller action buttons to free legend space */
   .chart-action-btn { padding: 0.2rem; }

--- a/styles.css
+++ b/styles.css
@@ -793,9 +793,10 @@ footer {
   /* Legend: tighter spacing, less clearance for action buttons */
   .chart-legend { gap: 0.15rem 0.5rem; padding-right: 40px; padding-bottom: 0.5rem; }
 
-  /* Mobile falls back to the flat legend (renderFlatLegend on mobile only).
-     Strip the grid class if it somehow survives, hide capability headers and
-     defeated link as a belt-and-suspenders defence. */
+  /* Mobile frontier uses .frontier-mobile (rendered by renderFrontierMobile) —
+     a wrapping row of capability pills. Race/cost modes still fall through
+     to the flat layout. If the desktop grid class somehow survives a resize,
+     strip it back to a flat row as a belt-and-suspenders defence. */
   .chart-legend.frontier-grid {
     display: flex;
     flex-wrap: wrap;
@@ -803,6 +804,32 @@ footer {
   }
   .legend-cap-header,
   .legend-defeated-link { display: none; }
+
+  .chart-legend.frontier-mobile {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.15rem 0.5rem;
+    padding-right: 40px;
+    padding-bottom: 0.5rem;
+  }
+
+  .legend-cap-pill {
+    background: none;
+    border: none;
+    padding: 0.3rem 0.35rem;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    cursor: pointer;
+    font-family: inherit;
+    /* Inline color override comes from renderFrontierMobile per pill. */
+  }
+
+  .legend-cap-pill.hidden {
+    opacity: 0.4;
+    text-decoration: line-through;
+  }
 
   /* Smaller action buttons to free legend space */
   .chart-action-btn { padding: 0.2rem; }

--- a/styles.css
+++ b/styles.css
@@ -185,13 +185,15 @@ main {
   position: relative;
 }
 
-/* Chart citation line */
+/* Chart citation line — info icon on the left, source text follows. Right side
+   reserved for the absolutely-positioned .chart-actions cluster. */
 .chart-citation {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 0.35rem;
   padding-top: 0.75rem;
+  padding-right: 90px;
   font-size: 0.7rem;
   color: var(--text-muted);
   flex-shrink: 0;
@@ -274,32 +276,46 @@ main {
 .chart-legend.frontier-grid {
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 0.4rem 0.85rem;
+  gap: 0.1rem 0.6rem;
   align-items: start;
-  padding-right: 70px;
+  padding-right: 0;
+  padding-top: 0;
+  padding-bottom: 0.6rem;
+  /* Chart-container has 1.5rem top padding; legend itself adds 0.6rem to its
+     bottom. Pull legend up so the visual space above and below the legend
+     within the container is roughly equal (rather than 24px top vs 10px bottom). */
+  margin-top: -0.45rem;
 }
 
 .legend-column {
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 0.1rem;
   min-width: 0; /* allows ellipsis instead of overflow on narrow columns */
 }
 
 .legend-cap-header {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 0.35rem;
   font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  /* Default colour for the header. Each rendered header span receives an inline
+     `color` override from renderCapabilityHeader — a lightened version of its
+     capability colour. The CSS fallback only applies if the JS override fails. */
   color: var(--text-muted);
   user-select: none;
-  padding: 0.1rem 0.25rem 0.2rem;
+  padding: 0 0.25rem;
+  min-width: 0;
+}
+
+/* Wrap the header text in a span so ellipsis works inside the flex layout */
+.legend-cap-header-text {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .legend-defeated-link {
@@ -308,11 +324,11 @@ main {
   padding: 0.15rem 0.25rem;
   font-size: 0.65rem;
   color: var(--text-muted);
-  text-decoration: underline dotted;
   cursor: pointer;
   text-align: left;
   font-family: inherit;
   white-space: nowrap;
+  text-decoration: none;
 }
 
 .legend-defeated-link:hover {
@@ -321,7 +337,13 @@ main {
 
 .legend-defeated-link.isolated {
   color: var(--text-primary);
-  text-decoration-style: solid;
+  font-weight: 600;
+}
+
+/* Within the capability-grouped grid, only the capability header carries the
+   coloured dot; the active benchmark name sits below as plain text. */
+.chart-legend.frontier-grid .legend-item .legend-dot {
+  display: none;
 }
 
 /* In the grid layout, individual benchmark buttons need to truncate gracefully */
@@ -362,10 +384,13 @@ main {
   color: #9ca3af;
 }
 
-/* Chart export buttons */
+/* Chart export buttons — pinned to the bottom-right of the chart-container so
+   they overlay the right end of the citation row. The citation row reserves
+   right-padding (set on .chart-citation) so the source text doesn't slide
+   underneath. */
 .chart-actions {
   position: absolute;
-  top: 0.6rem;
+  bottom: 0.6rem;
   right: 0.75rem;
   display: flex;
   gap: 0.35rem;
@@ -725,9 +750,9 @@ main {
 }
 
 .inactive-tooltip-score {
-  font-size: 0.8rem;
-  color: var(--text-primary);
-  font-weight: 500;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-weight: 400;
 }
 
 /* Footer */

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -5,6 +5,7 @@ const {
   compareQuarters,
   isBenchmarkActive,
   BENCHMARK_META,
+  CAPABILITIES,
   COST_BENCHMARK_META,
   LAB_KEYS,
 } = require("../lib/config.js");
@@ -85,20 +86,31 @@ describe("isBenchmarkActive", () => {
 describe("BENCHMARK_META", () => {
   const expectedKeys = [
     "gpqa", "arc-agi-2", "arc-agi-3", "hle", "swe-bench-pro", "aime", "frontiermath",
-    "osworld-verified",
+    "osworld-verified", "mmmu-pro",
     "humaneval", "arc-agi-1", "swe-bench-verified", "math-l5",
   ];
 
-  it("has all 12 expected benchmark keys", () => {
+  it("has all 13 expected benchmark keys", () => {
     for (const key of expectedKeys) {
       expect(BENCHMARK_META).toHaveProperty(key);
     }
-    expect(Object.keys(BENCHMARK_META)).toHaveLength(12);
+    expect(Object.keys(BENCHMARK_META)).toHaveLength(13);
   });
 
-  it("arc-agi-3 is active and in Reasoning category", () => {
+  it("arc-agi-3 is active and anchors Novel Problem Solving", () => {
     expect(BENCHMARK_META["arc-agi-3"].status).toBe("active");
-    expect(BENCHMARK_META["arc-agi-3"].category).toBe("Reasoning");
+    expect(BENCHMARK_META["arc-agi-3"].capability).toBe("Novel Problem Solving");
+  });
+
+  it("arc-agi-2 is deprecated as of Q2 2026 (replaced by ARC-AGI-3)", () => {
+    expect(BENCHMARK_META["arc-agi-2"].status).toBe("deprecated");
+    expect(BENCHMARK_META["arc-agi-2"].activeUntil).toBe("Q2 2026");
+    expect(BENCHMARK_META["arc-agi-2"].inactiveReason).toMatch(/ARC-AGI-3/);
+  });
+
+  it("mmmu-pro is active and anchors Visual Reasoning", () => {
+    expect(BENCHMARK_META["mmmu-pro"].status).toBe("active");
+    expect(BENCHMARK_META["mmmu-pro"].capability).toBe("Visual Reasoning");
   });
 
   it("osworld-verified is active and explicitly notes lab-coverage gaps in its description", () => {
@@ -111,10 +123,16 @@ describe("BENCHMARK_META", () => {
     for (const [key, meta] of Object.entries(BENCHMARK_META)) {
       expect(meta).toHaveProperty("name");
       expect(meta).toHaveProperty("description");
-      expect(meta).toHaveProperty("category");
+      expect(meta).toHaveProperty("capability");
       expect(meta).toHaveProperty("link");
       expect(meta).toHaveProperty("status");
       expect(["active", "saturated", "deprecated"]).toContain(meta.status);
+    }
+  });
+
+  it("every benchmark's capability is in the canonical CAPABILITIES list", () => {
+    for (const [key, meta] of Object.entries(BENCHMARK_META)) {
+      expect(CAPABILITIES).toContain(meta.capability);
     }
   });
 
@@ -124,6 +142,28 @@ describe("BENCHMARK_META", () => {
         expect(meta).toHaveProperty("activeUntil");
         expect(meta.activeUntil).toMatch(/^Q[1-4] \d{4}$/);
       }
+    }
+  });
+});
+
+// ─── CAPABILITIES ────────────────────────────────────────────
+
+describe("CAPABILITIES", () => {
+  it("has exactly 6 entries in canonical order", () => {
+    expect(CAPABILITIES).toEqual([
+      "Coding",
+      "Math",
+      "Expert Reasoning",
+      "Visual Reasoning",
+      "Computer Use",
+      "Novel Problem Solving",
+    ]);
+  });
+
+  it("every capability has at least one benchmark anchoring it", () => {
+    const usedCapabilities = new Set(Object.values(BENCHMARK_META).map(m => m.capability));
+    for (const cap of CAPABILITIES) {
+      expect(usedCapabilities).toContain(cap);
     }
   });
 });


### PR DESCRIPTION
## Summary

Reframes the Frontier Progress chart legend from a flat active/defeated list to **6 capability-grouped columns**, each anchored by one current best-in-class benchmark with an interactive \`N defeated\` link revealing the saturated/deprecated history. Targets the non-technical audience: a reader scanning the legend instantly sees "what AI is capable of now" rather than a wall of benchmark names.

**Capabilities (left to right)**: Coding · Math · Expert Reasoning · Visual Reasoning · Computer Use · Novel Problem Solving.

Hovering \`N defeated\` lights up all defeated lines in the capability colour with name labels at each endpoint, plus a multi-benchmark tooltip. Click isolates the chart to that group.

## Companion data + lifecycle changes (same PR for coherence)

- **\`BENCHMARK_META.category\` → \`capability\` rename** + value remap (Science folds into Expert Reasoning, Knowledge → Expert Reasoning, Reasoning → Novel Problem Solving, Agentic → Computer Use). New \`CAPABILITIES\` export from \`lib/config.js\`.
- **\`CATEGORY_COLORS\` → \`CAPABILITY_COLORS\`** in \`app.js\`. Per-benchmark \`BENCHMARK_COLORS\` const **deleted** — every benchmark now inherits its capability's colour. Inactive lines stay grey-dashed by default; pick up the capability colour on hover/isolation.
- **MMMU-Pro added** as the Visual Reasoning anchor. New \`fetchArtificialAnalysisMMMUPro()\` in \`scripts/update-data.js\` page-scrapes \`/evaluations/mmmu-pro\` (AA's models API doesn't expose mmmu_pro). Folds into the existing AA source-threshold check; aborts on <20 entries or unresolved UUIDs.
- **ARC-AGI-2 deprecated** (\`activeUntil: Q2 2026\`). Top frontier scores reached 83-85% across OpenAI / Google / Anthropic; ARC-AGI-3 (March 2026) is the field's new novel-reasoning anchor. Classified \`deprecated\` not \`saturated\` to match the ARC-AGI-1 precedent and honestly describe the field transition rather than a score-ceiling cluster.
- **Multi-benchmark tooltip** with the reason line dropped (peak score conveys the saturation story; methodology section carries deeper context).
- **Export canvas (\`buildExportCanvas\`)** redrawn to match the new 6-column grid layout. Ellipsis-truncates long names per column width.
- **Methodology section**: light update only — same layout, swap \`category\` to \`capability\` and re-colour dots by capability. Full restructure to capability-first headings deferred to a follow-up.
- **Tests**: 234 passing. Updated hardcoded \`"Reasoning"\` check to use the canonical \`CAPABILITIES\` list. New tests for ARC-AGI-2 deprecation, MMMU-Pro entry, capability-list completeness.

## What's NOT in this PR

- Race / Cost mode legends — Race needs the wider rethink in \`LAB_RACE_PLAN.md\` before reorganising.
- Within-capability colour differentiation (lightness variation) — not needed at v1 since every capability has 1 active; revisit when handoff periods produce multi-active capabilities.
- AI analysis prompt regen against the new capability labels — deferred to a manual run (production state change).
- MMMU-Pro ingestion run against Supabase — also deferred (production DB write; auto classifier blocked an unmerged-branch run, correctly per the no-destructive-actions-in-review rule).

## Test plan

- [ ] \`npm test\` — 234 vitest tests pass.
- [ ] Manual QA in browser at desktop (1400px), narrow desktop (1000px), tablet (768px), mobile (375px):
  - [ ] Frontier mode default: 6 columns, headers in capability colours, active benchmark per column, defeated count where present.
  - [ ] Click each active benchmark name: line isolates in capability colour.
  - [ ] Hover \`N defeated\` link: defeated lines turn capability colour, endpoint labels appear with names, multi-tooltip stacks above legend with no chart overlap.
  - [ ] Click \`N defeated\`: chart isolates to those datasets; click again to restore.
  - [ ] Switch to Lab Race: legend reverts to flat layout; race filter pills still colour by capability.
  - [ ] Switch to Cost: cost legend unchanged.
  - [ ] Switch back to Frontier: grid reinstates cleanly, no orphaned isolation state.
  - [ ] Mobile: capability headers + defeated link hidden; flat list of active benchmarks only.
  - [ ] Download chart PNG: 6 columns render, ellipsis on long names, citation visible.
  - [ ] Methodology section: each benchmark dot matches its capability colour; badge text shows new capability names.
- [ ] After merge: run \`node scripts/update-data.js\` to populate MMMU-Pro rows.
- [ ] After ingestion: run \`node scripts/generate-analyses.js\` to regenerate cached analyses against the new capability labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)