### PR TITLE
Show benchmark name on mobile capability pills

### DIFF
--- a/app.js
+++ b/app.js
@@ -894,16 +894,27 @@ function renderFrontierMobile(container, activeItems) {
   for (const cap of CAPABILITIES) {
     const items = grouped[cap].active;
     if (items.length === 0) continue;
-    const { idx } = items[0];
+    const { idx, ds } = items[0];
+    const benchName = BENCHMARK_META[ds._benchKey]?.name || "";
 
     const btn = document.createElement("button");
     btn.className = "legend-cap-pill";
     if (!chart.isDatasetVisible(idx)) btn.classList.add("hidden");
-    btn.textContent = cap;
-    btn.title = cap;
+    btn.title = benchName ? `${cap} · ${benchName}` : cap;
 
     const capColor = CAPABILITY_COLORS[cap];
-    if (capColor) btn.style.color = lightenHex(capColor, 0.45);
+    const capSpan = document.createElement("span");
+    capSpan.className = "legend-cap-name";
+    capSpan.textContent = cap;
+    if (capColor) capSpan.style.color = lightenHex(capColor, 0.45);
+    btn.appendChild(capSpan);
+
+    if (benchName) {
+      const benchSpan = document.createElement("span");
+      benchSpan.className = "legend-bench-name";
+      benchSpan.textContent = benchName;
+      btn.appendChild(benchSpan);
+    }
 
     btn.addEventListener("click", () => {
       if (isolatedCapability !== null) {

--- a/styles.css
+++ b/styles.css
@@ -814,6 +814,9 @@ footer {
   }
 
   .legend-cap-pill {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.3rem;
     background: none;
     border: none;
     padding: 0.3rem 0.35rem;
@@ -823,7 +826,14 @@ footer {
     text-transform: uppercase;
     cursor: pointer;
     font-family: inherit;
-    /* Inline color override comes from renderFrontierMobile per pill. */
+    /* .legend-cap-name carries the lightened capability colour (set inline). */
+  }
+
+  .legend-cap-pill .legend-bench-name {
+    font-weight: 400;
+    letter-spacing: 0.02em;
+    text-transform: none;
+    color: var(--text-muted, #808690);
   }
 
   .legend-cap-pill.hidden {


### PR DESCRIPTION
## Summary
- Each mobile capability pill now shows both the capability and the active benchmark behind it (e.g. `CODING SWE-bench Pro (Public)`).
- Benchmark name renders as a muted, normal-case sub-label so the capability still reads as the headline.
- `flex-wrap` handles layout: short pairs share a row, longer ones go solo. Typical iPhone width lands around 5 rows.
- Desktop frontier legend unchanged (mobile-only path).

## Why
Follow-up to #51: mobile users could see the capability labels but had no way to learn which benchmark each capability represented. This wires the answer in where the question gets asked.

## Test plan
- [ ] Verify on iPhone-sized viewport (~375px): each capability row reads as `CAPABILITY benchmark-name`
- [ ] Verify tap-to-isolate still works (whole pill remains the tap target)
- [ ] Verify on Android-sized viewport (~360px): nothing overflows
- [ ] Verify desktop frontier legend unchanged
- [ ] Verify hidden state (line-through + dimmed) still applies to whole row

🤖 Generated with [Claude Code](https://claude.com/claude-code)