### PR TITLE
Add MMLU-Pro, Aider Polyglot, Terminal-Bench 2.0 to benchmark cohort

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,7 +103,7 @@ function getVisibleSources() {
 
   const benchKeys = currentMode === "race"
     ? [currentBenchmark]
-    : Object.keys(BENCHMARKS);
+    : Object.keys(BENCHMARKS).filter(k => isInChartMode(k, currentMode));
 
   const sourceOrder = [
     "Artificial Analysis", "Epoch AI", "ARC Prize",
@@ -146,9 +146,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     showLoading(true);
     await loadData(); // from data-loader.js
-    // Default to first active benchmark key
+    // Default to first active benchmark key that's eligible for Race mode.
     if (!currentBenchmark || !BENCHMARKS[currentBenchmark]) {
-      currentBenchmark = Object.keys(BENCHMARKS).find(k => isBenchmarkActive(k, getFilterEndDate())) || Object.keys(BENCHMARKS)[0];
+      const filterEnd = getFilterEndDate();
+      currentBenchmark = Object.keys(BENCHMARKS).find(k => isBenchmarkActive(k, filterEnd) && isInChartMode(k, "race"))
+        || Object.keys(BENCHMARKS).find(k => isInChartMode(k, "race"))
+        || Object.keys(BENCHMARKS)[0];
     }
     populateDateRangeYears();
     renderModeToggle();
@@ -219,9 +222,10 @@ function renderFilterPills() {
 function renderBenchmarkPills(container) {
   const filterEnd = getFilterEndDate();
 
-  // Only show active benchmarks in Lab Race
+  // Only show active benchmarks in Lab Race, and only those eligible for Race
   for (const [key, bench] of Object.entries(BENCHMARKS)) {
     if (!isBenchmarkActive(key, filterEnd)) continue;
+    if (!isInChartMode(key, "race")) continue;
 
     const btn = document.createElement("button");
     btn.className = `filter-pill${key === currentBenchmark ? " active" : ""}`;
@@ -246,9 +250,9 @@ function renderBenchmarkPills(container) {
     container.appendChild(btn);
   }
 
-  // If current benchmark is inactive, switch to first active one
-  if (!isBenchmarkActive(currentBenchmark, filterEnd)) {
-    const firstActive = Object.keys(BENCHMARKS).find(k => isBenchmarkActive(k, filterEnd));
+  // If current benchmark is inactive or not race-eligible, switch to first active one
+  if (!isBenchmarkActive(currentBenchmark, filterEnd) || !isInChartMode(currentBenchmark, "race")) {
+    const firstActive = Object.keys(BENCHMARKS).find(k => isBenchmarkActive(k, filterEnd) && isInChartMode(k, "race"));
     if (firstActive) {
       currentBenchmark = firstActive;
       container.querySelector(".filter-pill")?.classList.add("active");
@@ -411,7 +415,9 @@ function buildFrontierDatasets() {
   const labKeys = selectedLab ? [selectedLab] : Object.keys(LABS);
   const filterEnd = getFilterEndDate();
 
-  return Object.entries(BENCHMARKS).map(([benchKey, benchData]) => {
+  return Object.entries(BENCHMARKS)
+    .filter(([benchKey]) => isInChartMode(benchKey, "frontier"))
+    .map(([benchKey, benchData]) => {
     const isInactive = !isBenchmarkActive(benchKey, filterEnd);
     const meta = BENCHMARK_META[benchKey];
 
@@ -1474,6 +1480,7 @@ function renderInfoArea() {
     const benchKeysByCapability = {};
     for (const cap of CAPABILITIES) benchKeysByCapability[cap] = { active: [], inactive: [] };
     for (const [key, bench] of Object.entries(BENCHMARKS)) {
+      if (!isInChartMode(key, currentMode)) continue;
       const meta = BENCHMARK_META[key];
       if (!meta || !benchKeysByCapability[meta.capability]) continue;
       const isInactive = !isBenchmarkActive(key, filterEnd);

--- a/app.js
+++ b/app.js
@@ -28,6 +28,9 @@ const BENCHMARK_SOURCE_MAP = {
   "math-l5":       "Epoch AI",
   "osworld-verified": "Epoch AI",
   "mmmu-pro":      "Artificial Analysis",
+  "mmlu-pro":      "Artificial Analysis",
+  "aider-polyglot": "Epoch AI",
+  "terminal-bench-2-0": "Epoch AI",
 };
 
 const COST_SOURCE = "Artificial Analysis";

--- a/lib/config.js
+++ b/lib/config.js
@@ -95,6 +95,7 @@ const BENCHMARK_META = {
     capability: "Coding",
     link: "https://tbench.ai/",
     status: "active",
+    chartModes: ["pace"], // Active Coding successor — would break Frontier's "1 active per capability" rule alongside SWE-bench Pro
   },
   // ─── Inactive benchmarks ───
   "humaneval": {
@@ -132,6 +133,7 @@ const BENCHMARK_META = {
     status: "saturated",
     activeUntil: "Q3 2025",
     inactiveReason: "Frontier scores plateaued around 88% in Q3 2025; likely ceiling from edit-format error rates rather than reasoning",
+    chartModes: ["frontier", "pace"], // Saturated — enriches Frontier history but no longer racing
   },
   "mmlu-pro": {
     name: "MMLU-Pro",
@@ -141,6 +143,7 @@ const BENCHMARK_META = {
     status: "saturated",
     activeUntil: "Q4 2025",
     inactiveReason: "Top frontier models clustered above 85% by Q4 2025; the field largely stopped reporting MMLU-Pro after AA's last refresh in early 2026",
+    chartModes: ["frontier", "pace"], // Saturated — enriches Frontier history but no longer racing
   },
   "math-l5": {
     name: "MATH Level 5",
@@ -232,6 +235,17 @@ function isBenchmarkActive(benchKey, filterEndQuarter) {
   return compareQuarters(filterEndQuarter, meta.activeUntil) < 0;
 }
 
+/** Returns true if a benchmark should appear in the given chart mode.
+ *  A missing `chartModes` field means the benchmark appears in every mode.
+ *  Used to keep saturated successors off the Race tab and active newcomers off
+ *  Frontier where they would break the "one active line per capability" rule. */
+function isInChartMode(benchKey, mode) {
+  const meta = BENCHMARK_META[benchKey];
+  if (!meta) return false;
+  if (!meta.chartModes) return true;
+  return meta.chartModes.includes(mode);
+}
+
 // ─── Analysis preset list ────────────────────────────────────
 
 /** Canonical list of date-range presets used by generate-analyses.js and
@@ -262,6 +276,7 @@ const _config = {
   compareQuarters,
   getFilterEndDate,
   isBenchmarkActive,
+  isInChartMode,
   getPresets,
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -89,6 +89,13 @@ const BENCHMARK_META = {
     link: "https://mmmu-benchmark.github.io/",
     status: "active",
   },
+  "terminal-bench-2-0": {
+    name: "Terminal-Bench 2.0",
+    description: "Real-world terminal tasks (file manipulation, debugging, multi-step CLI workflows) executed by an AI agent inside a containerised shell. Released June 2025 as a tougher successor to Terminal-Bench 1.0. Verified scores from Epoch AI's evaluation set, cross-checked against the official tbench.ai 2.0 leaderboard (top scores match exactly). Supplemented with unverified model card scores from the labs (shown with hollow dots).",
+    capability: "Coding",
+    link: "https://tbench.ai/",
+    status: "active",
+  },
   // ─── Inactive benchmarks ───
   "humaneval": {
     name: "HumanEval",
@@ -116,6 +123,24 @@ const BENCHMARK_META = {
     status: "saturated",
     activeUntil: "Q3 2025",
     inactiveReason: "Scores plateaued Q3 2025 due to known question-set ceiling; officially deprecated Feb 2026",
+  },
+  "aider-polyglot": {
+    name: "Aider Polyglot",
+    description: "Multi-language code editing benchmark from the Aider project. Models must apply diffs across 6 programming languages to fix realistic bugs, testing diff-format fluency alongside reasoning. Verified scores from Epoch AI; supplemented with unverified model card scores (shown with hollow dots).",
+    capability: "Coding",
+    link: "https://aider.chat/docs/leaderboards/",
+    status: "saturated",
+    activeUntil: "Q3 2025",
+    inactiveReason: "Frontier scores plateaued around 88% in Q3 2025; likely ceiling from edit-format error rates rather than reasoning",
+  },
+  "mmlu-pro": {
+    name: "MMLU-Pro",
+    description: "A harder successor to MMLU with 10 answer choices (vs 4) across 14 academic subjects, designed to test genuine reasoning rather than recall. Verified scores from Artificial Analysis's independent evaluations. Supplemented with unverified model card scores from the labs (shown with hollow dots).",
+    capability: "Expert Reasoning",
+    link: "https://arxiv.org/abs/2406.01574",
+    status: "saturated",
+    activeUntil: "Q4 2025",
+    inactiveReason: "Top frontier models clustered above 85% by Q4 2025; the field largely stopped reporting MMLU-Pro after AA's last refresh in early 2026",
   },
   "math-l5": {
     name: "MATH Level 5",

--- a/scripts/update-data.js
+++ b/scripts/update-data.js
@@ -67,6 +67,9 @@ const BENCHMARK_START_QUARTER = {
   "arc-agi-3":        "Q1 2026",  // Released as part of ARC Prize 2026
   "swe-bench-pro":    "Q3 2025",  // Scale AI SEAL leaderboard launched
   "osworld-verified": "Q3 2024",  // Original OSWorld launched Q2 2024; first frontier-lab scores Q3 2024
+  "mmlu-pro":         "Q2 2024",  // Released mid-2024 (arxiv.org/abs/2406.01574)
+  "aider-polyglot":   "Q1 2024",  // Earliest Epoch entries Mar 2024
+  "terminal-bench-2-0": "Q3 2025", // Terminal-Bench 2.0 released mid-2025
 };
 
 // Cost of Intelligence: benchmarks with price thresholds
@@ -85,6 +88,8 @@ const EPOCH_BENCHMARK_FILES = {
   "frontiermath.csv":             { key: "frontiermath", scoreCol: "mean_score" },
   "math_level_5.csv":             { key: "math-l5",      scoreCol: "mean_score" },
   "os_world_external.csv":        { key: "osworld-verified", scoreCol: "Score" },
+  "aider_polyglot_external.csv":  { key: "aider-polyglot", scoreCol: "Percent correct" },
+  "terminalbench_external.csv":   { key: "terminal-bench-2-0", scoreCol: "Accuracy mean" },
 };
 
 // Source-level abort thresholds. If a fetcher returns fewer rows than its threshold,
@@ -357,6 +362,19 @@ async function fetchArtificialAnalysis() {
         lab,
         model: modelName,
         score: evals.gpqa * 100,
+        date: releaseDate,
+        source: "artificialanalysis",
+        verified: true,
+      });
+    }
+
+    // MMLU-Pro
+    if (evals.mmlu_pro != null) {
+      results.push({
+        benchmark: "mmlu-pro",
+        lab,
+        model: modelName,
+        score: evals.mmlu_pro * 100,
         date: releaseDate,
         source: "artificialanalysis",
         verified: true,
@@ -962,7 +980,7 @@ async function main() {
   }
 
   // Automated benchmarks managed by this script. Manual seeds (humaneval) are excluded.
-  const automatedBenchmarks = ["swe-bench-verified", "arc-agi-1", "arc-agi-2", "arc-agi-3", "hle", "gpqa", "aime", "frontiermath", "math-l5", "swe-bench-pro", "osworld-verified", "mmmu-pro"];
+  const automatedBenchmarks = ["swe-bench-verified", "arc-agi-1", "arc-agi-2", "arc-agi-3", "hle", "gpqa", "aime", "frontiermath", "math-l5", "swe-bench-pro", "osworld-verified", "mmmu-pro", "mmlu-pro", "aider-polyglot", "terminal-bench-2-0"];
 
   // Compute cumulative best per (benchmark, lab) and build upsert rows
   const allRows = [];

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -86,15 +86,15 @@ describe("isBenchmarkActive", () => {
 describe("BENCHMARK_META", () => {
   const expectedKeys = [
     "gpqa", "arc-agi-2", "arc-agi-3", "hle", "swe-bench-pro", "aime", "frontiermath",
-    "osworld-verified", "mmmu-pro",
-    "humaneval", "arc-agi-1", "swe-bench-verified", "math-l5",
+    "osworld-verified", "mmmu-pro", "terminal-bench-2-0",
+    "humaneval", "arc-agi-1", "swe-bench-verified", "aider-polyglot", "mmlu-pro", "math-l5",
   ];
 
-  it("has all 13 expected benchmark keys", () => {
+  it("has all 16 expected benchmark keys", () => {
     for (const key of expectedKeys) {
       expect(BENCHMARK_META).toHaveProperty(key);
     }
-    expect(Object.keys(BENCHMARK_META)).toHaveLength(13);
+    expect(Object.keys(BENCHMARK_META)).toHaveLength(16);
   });
 
   it("arc-agi-3 is active and anchors Novel Problem Solving", () => {

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -4,6 +4,7 @@ const {
   generateTimeLabels,
   compareQuarters,
   isBenchmarkActive,
+  isInChartMode,
   BENCHMARK_META,
   CAPABILITIES,
   COST_BENCHMARK_META,
@@ -143,6 +144,36 @@ describe("BENCHMARK_META", () => {
         expect(meta.activeUntil).toMatch(/^Q[1-4] \d{4}$/);
       }
     }
+  });
+});
+
+// ─── chartModes ──────────────────────────────────────────────
+
+describe("chartModes / isInChartMode", () => {
+  it("benchmarks without chartModes default to every mode", () => {
+    expect(isInChartMode("gpqa", "frontier")).toBe(true);
+    expect(isInChartMode("gpqa", "race")).toBe(true);
+    expect(isInChartMode("gpqa", "pace")).toBe(true);
+    expect(isInChartMode("hle", "frontier")).toBe(true);
+    expect(isInChartMode("hle", "race")).toBe(true);
+  });
+
+  it("aider-polyglot and mmlu-pro appear on Frontier + Pace but not Race", () => {
+    for (const key of ["aider-polyglot", "mmlu-pro"]) {
+      expect(isInChartMode(key, "frontier")).toBe(true);
+      expect(isInChartMode(key, "pace")).toBe(true);
+      expect(isInChartMode(key, "race")).toBe(false);
+    }
+  });
+
+  it("terminal-bench-2-0 is Pace-only", () => {
+    expect(isInChartMode("terminal-bench-2-0", "pace")).toBe(true);
+    expect(isInChartMode("terminal-bench-2-0", "frontier")).toBe(false);
+    expect(isInChartMode("terminal-bench-2-0", "race")).toBe(false);
+  });
+
+  it("unknown benchmark keys return false", () => {
+    expect(isInChartMode("does-not-exist", "frontier")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Prereq for the upcoming Pace of Progress chart. Adds 3 benchmarks to the cohort and gates which chart modes each one appears on.

**3 new benchmarks**:
- **MMLU-Pro** (Expert Reasoning, saturated, `activeUntil: Q4 2025`) — AA models API exposes `mmlu_pro` directly.
- **Aider Polyglot** (Coding, saturated, `activeUntil: Q3 2025`) — Epoch `aider_polyglot_external.csv`. Frontier plateaued ~88% Q3 2025.
- **Terminal-Bench 2.0** (Coding, active) — Epoch `terminalbench_external.csv`. Verified against `tbench.ai` 2.0 leaderboard.

**`chartModes` gating** (new optional field on `BENCHMARK_META`; missing means every mode):
- Terminal-Bench 2.0 → `["pace"]`. It is an active Coding successor; including it on Frontier alongside SWE-bench Pro would break the "one active line per capability" rule.
- MMLU-Pro + Aider Polyglot → `["frontier", "pace"]`. Saturated. They enrich Frontier history as grey-dashed lines without crowding the Race tab.

New helper `isInChartMode(benchKey, mode)` applied in `buildFrontierDatasets`, `renderBenchmarkPills`, `getVisibleSources`, `renderInfoArea`, and the default-benchmark fallback. LLM-generated commentary intentionally untouched (separate rethink coming alongside upcoming chart changes).

## Test plan

- [x] `npm test` — 238 tests pass (234 existing + 4 new `isInChartMode` assertions).
- [x] Local headless smoke test (`playwright`):
  - Frontier chart includes `mmlu-pro` and `aider-polyglot`; excludes `terminal-bench-2-0`.
  - Race filter pills exclude all 3 new benchmarks.
- [ ] After merge: trigger the pipeline (manually or via Thursday weekly run) to backfill historical data.
- [ ] Visual check on `ai-race.vercel.app`:
  - Frontier: 2 new saturated Coding/Expert Reasoning lines render grey-dashed; Terminal-Bench 2.0 not present.
  - Race: filter pills unchanged.
  - Pace cohort has all 16 benchmarks once Pace chart PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
