### PR TITLE
Add Pace of Progress chart tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,6 +67,7 @@ let currentCostBenchmark = null; // null = all, or "gpqa" / "mmlu-pro"
 let currentDateRange = "all-time";
 let chart = null;
 let chartMode = null; // tracks which mode the chart was built for
+let paceBarChart = null; // second Chart.js instance, only built in pace mode
 let isolatedIndex = null;
 let highlightedInactiveIndex = null; // currently highlighted inactive dataset (single-line hover)
 let highlightedCapability = null;    // capability whose defeated group is hover-highlighted
@@ -212,8 +213,8 @@ function renderFilterPills() {
 
   if (currentMode === "race") {
     renderBenchmarkPills(container);
-  } else if (currentMode === "cost") {
-    // No pills — legend handles filtering via click-to-isolate
+  } else if (currentMode === "cost" || currentMode === "pace") {
+    // No pills — cost uses click-to-isolate in the legend; pace has no per-bench filter
   } else {
     renderLabPills(container);
   }
@@ -523,7 +524,157 @@ function buildFrontierDatasets() {
 function buildDatasets() {
   if (currentMode === "cost") return buildCostDatasets();
   if (currentMode === "race") return buildRaceDatasets();
+  if (currentMode === "pace") return buildPaceLineDatasets();
   return buildFrontierDatasets();
+}
+
+// ─── Pace of Progress ────────────────────────────────────────
+// The pace mode renders two charts: the headline line chart (in the existing
+// #benchmarkChart canvas) and a per-capability bar chart in a separate
+// #paceBarChart canvas that is hidden in other modes. Both are computed from
+// the pure `computePaceSeries()` in lib/pace-chart.js.
+
+function getPaceSeries() {
+  return computePaceSeries({
+    BENCHMARKS,
+    BENCHMARK_META,
+    CAPABILITIES,
+    TIME_LABELS,
+    now: getFilterEndDate(),
+  });
+}
+
+function buildPaceLineDatasets() {
+  const { lineSeries } = getPaceSeries();
+  // Map the pace series onto the full TIME_LABELS x-axis. Earlier quarters
+  // (pre-PACE_CHART_START) remain null so the line starts at Q4 2024.
+  const quarterToValue = Object.fromEntries(lineSeries.map(p => [p.quarter, p]));
+  const data = TIME_LABELS.map(q => quarterToValue[q]?.value ?? null);
+  const partialFlags = TIME_LABELS.map(q => quarterToValue[q]?.isPartial === true);
+  const contributorsByIdx = TIME_LABELS.map(q => quarterToValue[q]?.contributors ?? []);
+  const nByIdx = TIME_LABELS.map(q => quarterToValue[q]?.n ?? 0);
+
+  return [{
+    label: "Frontier pace",
+    data,
+    borderColor: "#e0e6f0",
+    backgroundColor: "rgba(224, 230, 240, 0.15)",
+    borderWidth: 2.5,
+    pointRadius: 4,
+    pointHoverRadius: 6,
+    pointBackgroundColor: partialFlags.map(p => p ? "transparent" : "#e0e6f0"),
+    pointBorderColor: "#e0e6f0",
+    pointBorderWidth: partialFlags.map(p => p ? 2 : 1),
+    tension: 0.25,
+    spanGaps: false,
+    segment: {
+      // Dash the segment that ENDS at a partial point.
+      borderDash: ctx => partialFlags[ctx.p1DataIndex] ? [6, 4] : undefined,
+    },
+    _paceContributors: contributorsByIdx,
+    _paceN: nByIdx,
+    _paceIsPartial: partialFlags,
+  }];
+}
+
+function buildPaceBarConfig() {
+  const { barSeries } = getPaceSeries();
+  const labels = barSeries.map(b => b.isLowN ? `${b.capability} (N=1)` : b.capability);
+  const data = barSeries.map(b => b.value);
+  const bgColors = barSeries.map(b => b.isLowN ? "transparent" : (CAPABILITY_COLORS[b.capability] || INACTIVE_COLOR));
+  const borderColors = barSeries.map(b => CAPABILITY_COLORS[b.capability] || INACTIVE_COLOR);
+  const borderWidths = barSeries.map(b => b.isLowN ? 2 : 1);
+
+  return {
+    type: "bar",
+    data: {
+      labels,
+      datasets: [{
+        label: "Avg pace (pp/quarter)",
+        data,
+        backgroundColor: bgColors,
+        borderColor: borderColors,
+        borderWidth: borderWidths,
+        borderRadius: 4,
+      }],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          enabled: true,
+          backgroundColor: "#1a1d27",
+          titleColor: "#e8eaed",
+          bodyColor: "#9aa0a6",
+          borderColor: "#2d3140",
+          borderWidth: 1,
+          padding: chartFontSize(10),
+          cornerRadius: 6,
+          titleFont: { size: chartFontSize(12) },
+          bodyFont: { size: chartFontSize(11) },
+          callbacks: {
+            label: ctx => {
+              const b = barSeries[ctx.dataIndex];
+              const lines = [`${b.value.toFixed(1)} pp / quarter`];
+              if (b.isLowN) lines.push("Single-benchmark proxy");
+              return lines;
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          grid: { color: GRID_COLOR },
+          ticks: { color: "#808690", font: { size: chartFontSize(11) } },
+        },
+        y: {
+          beginAtZero: true,
+          grid: { color: GRID_COLOR },
+          ticks: { color: "#808690", font: { size: chartFontSize(11) }, callback: val => val + " pp" },
+          title: { display: true, text: "pp per quarter", color: "#808690", font: { size: chartFontSize(11) } },
+        },
+      },
+      devicePixelRatio: CHART_DPR,
+    },
+  };
+}
+
+function updatePaceBarChart() {
+  const canvas = document.getElementById("paceBarChart");
+  if (!canvas) return;
+  if (paceBarChart) {
+    paceBarChart.destroy();
+    paceBarChart = null;
+  }
+  paceBarChart = new Chart(canvas.getContext("2d"), buildPaceBarConfig());
+}
+
+function destroyPaceBarChart() {
+  if (paceBarChart) {
+    paceBarChart.destroy();
+    paceBarChart = null;
+  }
+}
+
+// Toggle visibility of mode-specific UI chrome. Called from updateChart() so any
+// mode transition (including in/out of pace) reaches a consistent state.
+function setModeVisibility(mode) {
+  const dateRange = document.getElementById("dateRange");
+  const actions = document.querySelector(".chart-actions");
+  const filterPills = document.getElementById("filterPills");
+  const chartLegend = document.getElementById("chartLegend");
+  const paceWrapper = document.getElementById("paceBarChartWrapper");
+  const chartContainer = document.querySelector(".chart-container");
+  const isPace = mode === "pace";
+
+  if (dateRange)      dateRange.hidden     = isPace;
+  if (actions)        actions.hidden       = isPace;
+  if (filterPills)    filterPills.hidden   = isPace;
+  if (chartLegend)    chartLegend.hidden   = isPace;
+  if (paceWrapper)    paceWrapper.hidden   = !isPace;
+  if (chartContainer) chartContainer.classList.toggle("pace-mode", isPace);
 }
 
 // ─── Inactivity marker plugin ────────────────────────────────
@@ -721,6 +872,7 @@ function renderChart() {
     return;
   }
 
+  const isPace = currentMode === "pace";
   const yScale = isCost
     ? {
         type: "logarithmic",
@@ -736,6 +888,17 @@ function renderChart() {
             if (val >= 0.1) return "$" + val.toFixed(1);
             return "$" + val.toFixed(2);
           },
+        },
+      }
+    : isPace
+    ? {
+        beginAtZero: true,
+        title: { display: true, text: "Average pp gained per quarter", color: "#808690", font: { size: chartFontSize(11) }, padding: { top: 0, bottom: 4 } },
+        grid: { color: GRID_COLOR },
+        ticks: {
+          color: "#808690",
+          font: { size: chartFontSize(11) },
+          callback: val => val + " pp",
         },
       }
     : {
@@ -761,6 +924,16 @@ function renderChart() {
         if (lab) line += ` (${lab})`;
         if (score != null) line += `\n  Score: ${score}%`;
         return line.split("\n");
+      }
+    : isPace
+    ? function(context) {
+        const val = context.parsed.y;
+        if (val === null) return null;
+        const n = context.dataset._paceN?.[context.dataIndex] ?? 0;
+        const isPartial = context.dataset._paceIsPartial?.[context.dataIndex] === true;
+        const lines = [`${val.toFixed(1)} pp / quarter (avg across ${n} benchmarks)`];
+        if (isPartial) lines.push("Current quarter — in progress");
+        return lines;
       }
     : function(context) {
         const val = context.parsed.y;
@@ -865,6 +1038,7 @@ function renderCustomLegend() {
   container.classList.remove("frontier-grid", "frontier-mobile");
 
   if (!chart) return;
+  if (currentMode === "pace") return; // pace hides #chartLegend entirely
 
   const datasets = chart.data.datasets;
   const activeItems = [];
@@ -1415,19 +1589,29 @@ function updateChart() {
   hideInactiveTooltip();
   clearChartMessage();
 
-  // If switching between cost and non-cost, destroy and recreate (scale type changes)
-  const needsCost = currentMode === "cost";
-  const hadCost = chartMode === "cost";
-  if (needsCost !== hadCost) {
-    chart.destroy();
+  setModeVisibility(currentMode);
+
+  // Pace and cost both use different y-axis scales than frontier/race, so any
+  // transition into or out of them requires a full chart rebuild.
+  const needsRebuild =
+    (currentMode === "cost") !== (chartMode === "cost") ||
+    (currentMode === "pace") !== (chartMode === "pace");
+  if (needsRebuild) {
+    if (chart) chart.destroy();
+    if (currentMode !== "pace") destroyPaceBarChart();
     renderChart();
+    if (currentMode === "pace") updatePaceBarChart();
     renderCustomLegend();
     updateCitationLine();
     return;
   }
 
+  // Same scale class — update in place. Pace lives in this branch when re-entering
+  // pace mode without a scale change (shouldn't happen with current modes, but
+  // the bar chart still needs to refresh if data updates).
   chart.data.datasets = buildDatasets();
   chart.data.datasets.forEach((_, i) => chart.setDatasetVisibility(i, true));
+  if (currentMode === "pace") updatePaceBarChart();
   applyDateRange();
   renderCustomLegend();
   updateCitationLine();
@@ -1445,9 +1629,17 @@ function renderInfoArea() {
   const filterEnd = getFilterEndDate();
 
   // Methodology intro varies by mode
-  const methodologyText = currentMode === "cost"
-    ? "Shows the cheapest model (any lab) scoring above a fixed threshold on each benchmark, measured in $/M tokens (blended 3:1 input:output). Thresholds are set at what the best model scored when each benchmark launched. Uses cumulative minimum: once a cheaper model exists, the price floor never rises."
-    : 'Scores use independently verified sources wherever available (Artificial Analysis, Epoch AI, ARC Prize, SWE-bench, Scale AI SEAL), shown as solid dots. Where no independent evaluation exists yet, self-reported model card scores from official lab announcements are used, shown as <strong>hollow dots</strong>.';
+  let methodologyText;
+  if (currentMode === "cost") {
+    methodologyText = "Shows the cheapest model (any lab) scoring above a fixed threshold on each benchmark, measured in $/M tokens (blended 3:1 input:output). Thresholds are set at what the best model scored when each benchmark launched. Uses cumulative minimum: once a cheaper model exists, the price floor never rises.";
+  } else if (currentMode === "pace") {
+    methodologyText =
+      'Pace of Progress shows how fast frontier benchmark scores are moving, averaged across 16 benchmarks spanning 6 capabilities. The headline line is the average quarterly increase in best-known score; the bar chart breaks the last 12 months down by capability. ' +
+      '<br><br><strong>What counts in a quarter.</strong> A benchmark contributes its frontier movement that quarter, weighted equally with every other benchmark in the cohort. Saturated benchmarks (no longer advancing) contribute zero — that is what saturation looks like, and we keep them in the cohort up to their saturation quarter so the flatline is visible. ' +
+      '<br><br><strong>Caveats.</strong> Visual Reasoning and Computer Use are anchored by a single benchmark each (MMMU-Pro and OSWorld-Verified). Their bars are outlined to flag the small sample. ARC-AGI\'s three generations occasionally co-contribute in transition quarters (Q1 2025, Q2 2026) where one version winds down as its successor spins up. The current quarter is shown dashed because it is incomplete. The line starts at Q4 2024 — earlier quarters had several capabilities at N=0 and the cohort wasn\'t stable enough to read.';
+  } else {
+    methodologyText = 'Scores use independently verified sources wherever available (Artificial Analysis, Epoch AI, ARC Prize, SWE-bench, Scale AI SEAL), shown as solid dots. Where no independent evaluation exists yet, self-reported model card scores from official lab announcements are used, shown as <strong>hollow dots</strong>.';
+  }
 
   let html = `
     <div class="methodology-intro" id="methodologySection">
@@ -1657,6 +1849,14 @@ async function fetchAnalysis(preset) {
 
 function renderAnalysisCard(mode) {
   const section = document.getElementById("analysisSection");
+  // Pace doesn't ship with LLM commentary in v1 — hide the section entirely
+  // so we don't render an empty "No analysis" card under the chart.
+  if (mode === "pace") {
+    section.hidden = true;
+    section.innerHTML = "";
+    return;
+  }
+  section.hidden = false;
   if (!cachedAnalysis) {
     section.innerHTML = '<div class="analysis-empty">No analysis available for this time range.</div>';
     return;

--- a/data-loader.js
+++ b/data-loader.js
@@ -16,32 +16,40 @@ let costLoadFailed = false;
 async function loadBenchmarkScores() {
   // select=* keeps this query schema-tolerant: if a new column (e.g. model_variant)
   // hasn't been migrated yet, the query still succeeds and the field is undefined.
-  const url = `${SUPABASE_URL}/rest/v1/benchmark_scores?select=*&order=benchmark,lab,quarter`;
+  // Paginate because Supabase caps a single response at 1000 rows; we passed
+  // that threshold when the Pace cohort grew (terminal-bench-2-0, sorted last
+  // alphabetically, was being silently truncated).
+  const PAGE_SIZE = 1000;
+  const rows = [];
+  for (let offset = 0; ; offset += PAGE_SIZE) {
+    const url = `${SUPABASE_URL}/rest/v1/benchmark_scores?select=*&order=benchmark,lab,quarter&limit=${PAGE_SIZE}&offset=${offset}`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15000);
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 15000);
-
-  let response;
-  try {
-    response = await fetch(url, {
-      headers: {
-        "apikey": SUPABASE_ANON_KEY,
-        "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
-      },
-      signal: controller.signal,
-    });
-  } catch (err) {
+    let response;
+    try {
+      response = await fetch(url, {
+        headers: {
+          "apikey": SUPABASE_ANON_KEY,
+          "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
+        },
+        signal: controller.signal,
+      });
+    } catch (err) {
+      clearTimeout(timeoutId);
+      if (err.name === "AbortError") throw new Error("Request timed out");
+      throw err;
+    }
     clearTimeout(timeoutId);
-    if (err.name === "AbortError") throw new Error("Request timed out");
-    throw err;
-  }
-  clearTimeout(timeoutId);
 
-  if (!response.ok) {
-    throw new Error(`Supabase fetch failed: ${response.status} ${response.statusText}`);
-  }
+    if (!response.ok) {
+      throw new Error(`Supabase fetch failed: ${response.status} ${response.statusText}`);
+    }
 
-  const rows = await response.json();
+    const batch = await response.json();
+    rows.push(...batch);
+    if (batch.length < PAGE_SIZE) break;
+  }
 
   // Build quarter → index lookup
   const quarterIndex = {};

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
         <button class="mode-btn active" data-mode="frontier" role="tab" aria-selected="true">AI Frontier</button>
         <button class="mode-btn" data-mode="race" role="tab" aria-selected="false">Lab Race</button>
         <button class="mode-btn" data-mode="cost" role="tab" aria-selected="false">Cost of Intelligence</button>
+        <button class="mode-btn" data-mode="pace" role="tab" aria-selected="false">Pace of Progress</button>
       </div>
       <select id="dateRange" class="date-range-select">
         <option value="all-time" selected>All-time</option>
@@ -67,6 +68,10 @@
       <div class="chart-canvas-wrapper">
         <canvas id="benchmarkChart"></canvas>
       </div>
+      <div class="pace-bar-wrapper" id="paceBarChartWrapper" hidden>
+        <h3 class="pace-bar-title">Average pace by capability — last 12 months</h3>
+        <canvas id="paceBarChart"></canvas>
+      </div>
       <div class="chart-citation" id="chartCitation"></div>
     </div>
 
@@ -92,6 +97,7 @@
   </footer>
 
   <script src="lib/config.js"></script>
+  <script src="lib/pace-chart.js"></script>
   <script src="data-loader.js"></script>
   <script src="app.js"></script>
   <script>window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };</script>

--- a/lib/pace-chart.js
+++ b/lib/pace-chart.js
@@ -1,0 +1,175 @@
+// lib/pace-chart.js
+// Pace of Progress chart aggregation. Pure functions; no Supabase, no DOM.
+// Dual-export (CommonJS + browser global) following lib/config.js.
+
+// The 16-benchmark cohort. Listed in capability groups for readability.
+const PACE_COHORT = [
+  // Coding (5)
+  "swe-bench-pro", "swe-bench-verified", "aider-polyglot", "terminal-bench-2-0", "humaneval",
+  // Math (3)
+  "frontiermath", "aime", "math-l5",
+  // Expert Reasoning (3)
+  "hle", "gpqa", "mmlu-pro",
+  // Novel Problem Solving (3)
+  "arc-agi-1", "arc-agi-2", "arc-agi-3",
+  // Visual Reasoning (1)
+  "mmmu-pro",
+  // Computer Use (1)
+  "osworld-verified",
+];
+
+// Hard-clip: the headline line starts here. Earlier quarters are dropped to avoid
+// the cohort-stability artefact (pre-Q4 2024 the cohort had several capabilities at N=0).
+const PACE_CHART_START = "Q4 2024";
+
+// Bar chart window: last N quarters.
+const PACE_BAR_WINDOW = 4;
+
+function _compareQuarters(a, b) {
+  const [qa, ya] = [parseInt(a[1]), parseInt(a.substring(3))];
+  const [qb, yb] = [parseInt(b[1]), parseInt(b.substring(3))];
+  return ya !== yb ? ya - yb : qa - qb;
+}
+
+// Inclusive lifecycle gate (matches scratch v3 convention): a saturated/deprecated
+// benchmark counts in quarter Q if Q <= activeUntil. Different from lib/config's
+// `isBenchmarkActive`, which is strict (inactive AT activeUntil) — Pace deliberately
+// includes the final saturation quarter so the visible flatline is in the cohort.
+function _isInFlightAtQuarter(meta, quarter) {
+  if (!meta) return false;
+  if (meta.status === "active") return true;
+  if (!meta.activeUntil) return false;
+  return _compareQuarters(quarter, meta.activeUntil) <= 0;
+}
+
+// Frontier score per quarter for one benchmark: max across labs of the pre-computed
+// per-lab cumulative-best (already in benchmark_scores). The max-across-labs at each
+// quarter is already monotonic because each lab's cell is itself cumulative-best.
+function _frontierByQuarter(benchData, timeLabels) {
+  const frontier = new Array(timeLabels.length).fill(null);
+  let last = null;
+  for (let i = 0; i < timeLabels.length; i++) {
+    let maxAtQ = null;
+    for (const labKey of Object.keys(benchData.scores)) {
+      const cell = benchData.scores[labKey][i];
+      if (cell && cell.score != null) {
+        if (maxAtQ == null || cell.score > maxAtQ) maxAtQ = cell.score;
+      }
+    }
+    if (maxAtQ != null) last = last == null ? maxAtQ : Math.max(last, maxAtQ);
+    frontier[i] = last;
+  }
+  return frontier;
+}
+
+/**
+ * Compute the Pace of Progress series.
+ *
+ * @param {Object} params
+ * @param {Object} params.BENCHMARKS    - {benchKey: {capability, scores: {lab: [perQuarter]}}}
+ * @param {Object} params.BENCHMARK_META- {benchKey: {status, activeUntil, capability}}
+ * @param {string[]} params.CAPABILITIES- canonical order, drives bar order
+ * @param {string[]} params.TIME_LABELS - ["Q1 2023", ...]
+ * @param {string}  params.now          - current quarter, e.g. "Q2 2026"
+ * @param {string[]} [params.cohort]    - override the default 16-key cohort
+ *
+ * @returns {{
+ *   lineSeries: Array<{ quarter, value, n, isPartial, contributors }>,
+ *   barSeries:  Array<{ capability, value, n, isLowN, contributors }>
+ * }}
+ */
+function computePaceSeries({ BENCHMARKS, BENCHMARK_META, CAPABILITIES, TIME_LABELS, now, cohort }) {
+  const COHORT = cohort || PACE_COHORT;
+
+  // Per-benchmark frontier curve.
+  const frontierByBench = {};
+  for (const benchKey of COHORT) {
+    const benchData = BENCHMARKS[benchKey];
+    if (!benchData) continue;
+    frontierByBench[benchKey] = _frontierByQuarter(benchData, TIME_LABELS);
+  }
+
+  // Per-benchmark quarterly delta.
+  const deltaByBench = {};
+  for (const [benchKey, frontier] of Object.entries(frontierByBench)) {
+    const deltas = new Array(TIME_LABELS.length).fill(null);
+    for (let i = 1; i < TIME_LABELS.length; i++) {
+      if (frontier[i] != null && frontier[i - 1] != null) {
+        deltas[i] = +(frontier[i] - frontier[i - 1]).toFixed(2);
+      }
+    }
+    deltaByBench[benchKey] = deltas;
+  }
+
+  // Headline line: per-quarter mean delta across in-flight cohort, clipped to PACE_CHART_START.
+  const startIdx = TIME_LABELS.indexOf(PACE_CHART_START);
+  const lineSeries = [];
+  for (let i = Math.max(0, startIdx); i < TIME_LABELS.length; i++) {
+    const quarter = TIME_LABELS[i];
+    const contributors = [];
+    for (const benchKey of COHORT) {
+      const meta = BENCHMARK_META[benchKey];
+      if (!_isInFlightAtQuarter(meta, quarter)) continue;
+      const delta = deltaByBench[benchKey]?.[i];
+      if (delta == null) continue;
+      contributors.push({ benchKey, delta });
+    }
+    const n = contributors.length;
+    const mean = n > 0
+      ? +(contributors.reduce((s, c) => s + c.delta, 0) / n).toFixed(2)
+      : null;
+    lineSeries.push({
+      quarter,
+      value: mean,
+      n,
+      isPartial: quarter === now,
+      contributors,
+    });
+  }
+
+  // Bar chart: per-capability mean over the trailing 4 quarters.
+  const nowIdx = TIME_LABELS.indexOf(now);
+  const windowQuarters = [];
+  for (let offset = PACE_BAR_WINDOW - 1; offset >= 0; offset--) {
+    const idx = nowIdx - offset;
+    if (idx >= 0) windowQuarters.push(TIME_LABELS[idx]);
+  }
+
+  const barSeries = [];
+  for (const capability of CAPABILITIES) {
+    const cohortInCap = COHORT.filter(b => BENCHMARK_META[b]?.capability === capability);
+    const deltas = [];
+    for (const benchKey of cohortInCap) {
+      const meta = BENCHMARK_META[benchKey];
+      for (const quarter of windowQuarters) {
+        if (!_isInFlightAtQuarter(meta, quarter)) continue;
+        const qIdx = TIME_LABELS.indexOf(quarter);
+        const delta = deltaByBench[benchKey]?.[qIdx];
+        if (delta == null) continue;
+        deltas.push(delta);
+      }
+    }
+    const value = deltas.length > 0
+      ? +(deltas.reduce((s, d) => s + d, 0) / deltas.length).toFixed(2)
+      : 0;
+    barSeries.push({
+      capability,
+      value,
+      n: cohortInCap.length,
+      isLowN: cohortInCap.length === 1,
+      contributors: cohortInCap,
+    });
+  }
+
+  return { lineSeries, barSeries };
+}
+
+const _paceChart = {
+  PACE_COHORT,
+  PACE_CHART_START,
+  PACE_BAR_WINDOW,
+  computePaceSeries,
+};
+
+if (typeof module !== "undefined" && module.exports) module.exports = _paceChart;
+if (typeof window !== "undefined") Object.assign(window, _paceChart);

--- a/styles.css
+++ b/styles.css
@@ -97,6 +97,7 @@ main {
 /* Mode toggle */
 .mode-toggle {
   display: inline-flex;
+  flex-wrap: wrap;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -179,10 +180,43 @@ main {
   flex-direction: column;
 }
 
+/* Pace of Progress: container hosts both the line chart and a bar chart, so
+   the fixed height becomes too cramped. Give each canvas an explicit height
+   instead and let the container expand. */
+.chart-container.pace-mode {
+  height: auto;
+}
+.chart-container.pace-mode .chart-canvas-wrapper {
+  flex: none;
+  height: 18rem;
+}
+
 .chart-canvas-wrapper {
   flex: 1;
   min-height: 0;
   position: relative;
+}
+
+/* Pace of Progress: bar chart rendered beneath the headline line chart.
+   Hidden in other modes (via [hidden] attribute toggled in app.js). */
+.pace-bar-wrapper {
+  flex-shrink: 0;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.pace-bar-title {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  margin: 0 0 0.75rem 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.pace-bar-wrapper canvas {
+  max-height: 220px;
 }
 
 /* Chart citation line — info icon on the left, source text follows. Right side
@@ -393,6 +427,14 @@ main {
   display: flex;
   gap: 0.35rem;
   z-index: 10;
+}
+
+/* Restore the default `hidden` attribute behaviour for elements whose
+   `display` is set explicitly (which otherwise overrides display:none). */
+.chart-actions[hidden],
+.filter-pills[hidden],
+.chart-legend[hidden] {
+  display: none;
 }
 
 .chart-action-btn {
@@ -783,6 +825,9 @@ footer {
   .controls { flex-direction: column; gap: 0.5rem; }
   .date-range-select { width: 100%; }
   .chart-container { height: 28rem; padding: 1rem; }
+  .chart-container.pace-mode { height: auto; }
+  .chart-container.pace-mode .chart-canvas-wrapper { height: 16rem; }
+  .pace-bar-wrapper canvas { max-height: 200px; }
   .filter-pill { font-size: 0.75rem; padding: 0.35rem 0.75rem; }
   .filter-pills { gap: 0.35rem; }
   .analysis-card { padding: 0.75rem 1rem; }

--- a/tests/pace-chart.test.js
+++ b/tests/pace-chart.test.js
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+
+const { computePaceSeries, PACE_COHORT, PACE_CHART_START } = require("../lib/pace-chart.js");
+
+// ─── Fixtures ────────────────────────────────────────────────
+
+const CAPABILITIES = ["Coding", "Math", "Expert Reasoning", "Visual Reasoning", "Computer Use", "Novel Problem Solving"];
+
+// Mini timeline covering Q1 2024 → Q2 2026 (10 quarters).
+const TIME_LABELS = [
+  "Q1 2024", "Q2 2024", "Q3 2024", "Q4 2024",
+  "Q1 2025", "Q2 2025", "Q3 2025", "Q4 2025",
+  "Q1 2026", "Q2 2026",
+];
+
+function cellsFromArray(arr) {
+  // helper: number → cumulative cell shape used by data-loader
+  return arr.map(v => v == null ? null : { score: v, model: "test", source: "epoch", verified: true, variant: null });
+}
+
+function buildBench(scoresByLab) {
+  // scoresByLab: {labKey: number[]} where each number is the lab's cumulative-best at that quarter
+  const scores = {};
+  for (const [lab, arr] of Object.entries(scoresByLab)) scores[lab] = cellsFromArray(arr);
+  return { scores };
+}
+
+// ─── Tests ───────────────────────────────────────────────────
+
+describe("computePaceSeries — line series", () => {
+  it("clips to PACE_CHART_START (Q4 2024) and runs through now", () => {
+    const BENCHMARKS = {
+      "hle": buildBench({ openai: [10, 20, 30, 40, 50, 55, 60, 62, 64, 65] }),
+    };
+    const BENCHMARK_META = { "hle": { status: "active", capability: "Expert Reasoning" } };
+
+    const { lineSeries } = computePaceSeries({
+      BENCHMARKS, BENCHMARK_META, CAPABILITIES, TIME_LABELS, now: "Q2 2026",
+      cohort: ["hle"],
+    });
+
+    expect(lineSeries[0].quarter).toBe("Q4 2024");
+    expect(lineSeries[lineSeries.length - 1].quarter).toBe("Q2 2026");
+  });
+
+  it("flags the current quarter as partial", () => {
+    const BENCHMARKS = {
+      "hle": buildBench({ openai: [10, 20, 30, 40, 50, 55, 60, 62, 64, 65] }),
+    };
+    const BENCHMARK_META = { "hle": { status: "active", capability: "Expert Reasoning" } };
+
+    const { lineSeries } = computePaceSeries({
+      BENCHMARKS, BENCHMARK_META, CAPABILITIES, TIME_LABELS, now: "Q2 2026",
+      cohort: ["hle"],
+    });
+
+    const last = lineSeries[lineSeries.length - 1];
+    expect(last.isPartial).toBe(true);
+    // Only the most recent quarter is partial.
+    const others = lineSeries.slice(0, -1).filter(p => p.isPartial);
+    expect(others).toHaveLength(0);
+  });
+
+  it("lifecycle gate excludes saturated/deprecated benchmarks past activeUntil", () => {
+    // humaneval saturated, activeUntil = Q4 2024. Q1 2025+ excluded.
+    // hle active, contributes every quarter.
+    const BENCHMARKS = {
+      "humaneval": buildBench({ openai: [70, 80, 90, 95, 96, 97, 97, 97, 97, 97] }),
+      "hle":       buildBench({ openai: [10, 20, 30, 40, 50, 60, 65, 70, 73, 75] }),
+    };
+    const BENCHMARK_META = {
+      "humaneval": { status: "saturated", activeUntil: "Q4 2024", capability: "Coding" },
+      "hle":       { status: "active",                            capability: "Expert Reasoning" },
+    };
+
+    const { lineSeries } = computePaceSeries({
+      BENCHMARKS, BENCHMARK_META, CAPABILITIES, TIME_LABELS, now: "Q2 2026",
+      cohort: ["humaneval", "hle"],
+    });
+
+    // Q4 2024: humaneval still in-flight (95-90=5, both at activeUntil), hle +10 → mean (5+10)/2 = 7.5
+    const q4_2024 = lineSeries.find(p => p.quarter === "Q4 2024");
+    expect(q4_2024.n).toBe(2);
+    expect(q4_2024.contributors.map(c => c.benchKey).sort()).toEqual(["hle", "humaneval"]);
+
+    // Q1 2025: humaneval excluded (past activeUntil), hle alone +10
+    const q1_2025 = lineSeries.find(p => p.quarter === "Q1 2025");
+    expect(q1_2025.n).toBe(1);
+    expect(q1_2025.contributors[0].benchKey).toBe("hle");
+  });
+
+  it("counts saturated benchmarks at zero pace within their activeUntil window", () => {
+    // humaneval frozen at 95 from Q3 2024 onwards but in-flight through Q4 2024.
+    const BENCHMARKS = {
+      "humaneval": buildBench({ openai: [80, 90, 95, 95, 95, 95, 95, 95, 95, 95] }),
+    };
+    const BENCHMARK_META = {
+      "humaneval": { status: "saturated", activeUntil: "Q4 2024", capability: "Coding" },
+    };
+
+    const { lineSeries } = computePaceSeries({
+      BENCHMARKS, BENCHMARK_META, CAPABILITIES, TIME_LABELS, now: "Q2 2026",
+      cohort: ["humaneval"],
+    });
+
+    // Q4 2024 (last in-flight quarter): humaneval frozen → delta 0.
+    const q4_2024 = lineSeries.find(p => p.quarter === "Q4 2024");
+    expect(q4_2024.value).toBe(0);
+    expect(q4_2024.n).toBe(1);
+  });
+
+  it("handles ARC overlap: ARC-AGI-1 and ARC-AGI-2 both contribute in their transition quarter", () => {
+    // ARC-AGI-1 activeUntil Q1 2025; ARC-AGI-2 active.
+    // ARC-AGI-2 has a fresh score in Q4 2024 (early submissions), so Q1 2025 delta exists.
+    // In Q1 2025, both are in-flight AND both have prior-quarter frontier → both contribute.
+    const BENCHMARKS = {
+      "arc-agi-1": buildBench({ openai: [10, 15, 20, 30, 50, 50, 50, 50, 50, 50] }),
+      "arc-agi-2": buildBench({ openai: [null, null, null, 3, 8, 12, 15, 20, 25, 30] }),
+    };
+    const BENCHMARK_META = {
+      "arc-agi-1": { status: "deprecated", activeUntil: "Q1 2025", capability: "Novel Problem Solving" },
+      "arc-agi-2": { status: "active",                              capability: "Novel Problem Solving" },
+    };
+
+    const { lineSeries } = computePaceSeries({
+      BENCHMARKS, BENCHMARK_META, CAPABILITIES, TIME_LABELS, now: "Q2 2026",
+      cohort: ["arc-agi-1", "arc-agi-2"],
+    });
+
+    // Q1 2025 deltas: arc-agi-1 = 50-30 = 20; arc-agi-2 = 8-3 = 5. Both contribute.
+    const q1_2025 = lineSeries.find(p => p.quarter === "Q1 2025");
+    expect(q1_2025.n).toBe(2);
+    expect(q1_2025.contributors.map(c => c.benchKey).sort()).toEqual(["arc-agi-1", "arc-agi-2"]);
+    expect(Number.isFinite(q1_2025.value)).toBe(true);
+  });
+});
+
+describe("computePaceSeries — bar series", () => {
+  it("averages over the last 12 months (4 trailing quarters)", () => {
+    // hle: Q3 2025 to Q2 2026 deltas of [2, 3, 4, 5] → mean = 3.5
+    const BENCHMARKS = {
+      "hle": buildBench({ openai: [10, 20, 30, 40, 50, 55, 58, 61, 65, 70] }),
+    };
+    const BENCHMARK_META = { "hle": { status: "active", capability: "Expert Reasoning" } };
+
+    const { barSeries } = computePaceSeries({
+      BENCHMARKS, BENCHMARK_META, CAPABILITIES, TIME_LABELS, now: "Q2 2026",
+      cohort: ["hle"],
+    });
+
+    const er = barSeries.find(b => b.capability === "Expert Reasoning");
+    // Q3 2025 (58-55=3), Q4 2025 (61-58=3), Q1 2026 (65-61=4), Q2 2026 (70-65=5) → mean = 3.75
+    expect(er.value).toBeCloseTo(3.75, 1);
+    expect(er.n).toBe(1);
+    expect(er.isLowN).toBe(true);
+  });
+
+  it("flags N=1 capabilities (Visual Reasoning, Computer Use in default cohort)", () => {
+    const BENCHMARKS = {
+      "mmmu-pro":         buildBench({ openai: [10, 15, 20, 25, 30, 35, 40, 45, 50, 55] }),
+      "osworld-verified": buildBench({ anthropic: [null, null, 10, 15, 20, 25, 30, 35, 40, 45] }),
+      "hle":              buildBench({ openai: [10, 20, 30, 40, 50, 55, 58, 61, 65, 70] }),
+      "gpqa":             buildBench({ openai: [50, 55, 60, 65, 70, 75, 80, 85, 88, 90] }),
+    };
+    const BENCHMARK_META = {
+      "mmmu-pro":         { status: "active", capability: "Visual Reasoning" },
+      "osworld-verified": { status: "active", capability: "Computer Use" },
+      "hle":              { status: "active", capability: "Expert Reasoning" },
+      "gpqa":             { status: "active", capability: "Expert Reasoning" },
+    };
+
+    const { barSeries } = computePaceSeries({
+      BENCHMARKS, BENCHMARK_META, CAPABILITIES, TIME_LABELS, now: "Q2 2026",
+      cohort: ["mmmu-pro", "osworld-verified", "hle", "gpqa"],
+    });
+
+    expect(barSeries.find(b => b.capability === "Visual Reasoning").isLowN).toBe(true);
+    expect(barSeries.find(b => b.capability === "Computer Use").isLowN).toBe(true);
+    expect(barSeries.find(b => b.capability === "Expert Reasoning").isLowN).toBe(false);
+    expect(barSeries.find(b => b.capability === "Expert Reasoning").n).toBe(2);
+  });
+
+  it("returns value=0 (not NaN) for a capability whose benchmarks are all past activeUntil", () => {
+    // Math: math-l5 saturated Q1 2025, frontiermath also saturated Q1 2025 (synthetic for this test).
+    // Both past activeUntil before the bar window (Q3 2025 → Q2 2026). No contributors.
+    const BENCHMARKS = {
+      "math-l5":      buildBench({ openai: [80, 90, 95, 95, 95, 95, 95, 95, 95, 95] }),
+      "frontiermath": buildBench({ openai: [10, 15, 20, 22, 22, 22, 22, 22, 22, 22] }),
+    };
+    const BENCHMARK_META = {
+      "math-l5":      { status: "saturated", activeUntil: "Q1 2025", capability: "Math" },
+      "frontiermath": { status: "saturated", activeUntil: "Q1 2025", capability: "Math" },
+    };
+
+    const { barSeries } = computePaceSeries({
+      BENCHMARKS, BENCHMARK_META, CAPABILITIES, TIME_LABELS, now: "Q2 2026",
+      cohort: ["math-l5", "frontiermath"],
+    });
+
+    const math = barSeries.find(b => b.capability === "Math");
+    expect(math.value).toBe(0);
+    expect(Number.isFinite(math.value)).toBe(true);
+  });
+
+  it("returns one bar per capability in the canonical order", () => {
+    const { barSeries } = computePaceSeries({
+      BENCHMARKS: {},
+      BENCHMARK_META: {},
+      CAPABILITIES,
+      TIME_LABELS,
+      now: "Q2 2026",
+      cohort: [],
+    });
+    expect(barSeries.map(b => b.capability)).toEqual(CAPABILITIES);
+  });
+});
+
+describe("PACE_COHORT", () => {
+  it("has exactly 16 benchmarks", () => {
+    expect(PACE_COHORT).toHaveLength(16);
+  });
+
+  it("contains the canonical Pace cohort", () => {
+    const expected = [
+      "swe-bench-pro", "swe-bench-verified", "aider-polyglot", "terminal-bench-2-0", "humaneval",
+      "frontiermath", "aime", "math-l5",
+      "hle", "gpqa", "mmlu-pro",
+      "arc-agi-1", "arc-agi-2", "arc-agi-3",
+      "mmmu-pro",
+      "osworld-verified",
+    ];
+    expect(PACE_COHORT.sort()).toEqual(expected.sort());
+  });
+});
+
+describe("PACE_CHART_START", () => {
+  it("is Q4 2024", () => {
+    expect(PACE_CHART_START).toBe("Q4 2024");
+  });
+});


### PR DESCRIPTION
## Summary

Adds the "Pace of Progress" tab — a 4th chart mode that answers _"is AI progress accelerating, plateauing, or steady, and which capabilities are moving fastest?"_ with two charts on one tab:

- **Headline line** — flat mean of quarterly frontier deltas across a 16-benchmark cohort. Raw (not smoothed). Q4 2024 onwards. The current quarter renders dashed with a hollow endpoint to flag "in progress".
- **Bar chart underneath** — per-capability average pace over the last 12 months. Capabilities with N=1 benchmarks (Visual Reasoning, Computer Use) render outline-only with a `(N=1)` tick suffix so the small sample is visible at a glance.

The headline question and the capability question each get the chart shape best suited to them: one interpretable headline number, one decomposition. The bar chart is where the capability lens lives — keeping the headline's unit interpretable as "pp per quarter, raw average across the cohort".

Cohort + methodology locked after a session-2 red team (see `PACE_PLAN.md`). Key decisions:
- **Flat mean over capability-weighted** — the latter amplified N=1 buckets 2.7× and broke the headline's quotable unit.
- **Saturated benchmarks contribute 0** within their `activeUntil` window. Saturation should look like flatlining — that's what it is.
- **ARC-AGI overlap in transition quarters** disclosed in methodology, not special-cased (one clean rule across all benchmarks).
- **No 4Q smoothing** — keeps the o1 inflection point legible.

## Out of scope for v1

- LLM commentary for pace mode (deferred to future PR)
- Custom export canvas (export buttons hidden in pace mode)
- Date-range dropdown coupling (hidden in pace mode; both windows are fixed)
- Confidence intervals / sensitivity ribbon
- Bonus AA benchmarks (SciCode, IFBench, AA-LCR, etc.)

## Architecture

- **`lib/pace-chart.js`** (new) — pure function `computePaceSeries()`. Dual CommonJS + browser export. Reads from the already-loaded `BENCHMARKS` global; derives per-benchmark frontier per quarter; applies lifecycle + activity gates. No new ingestion path (cumulative-best is pre-computed in Supabase rows).
- **`tests/pace-chart.test.js`** (new) — 12 tests pinning the methodology: lifecycle flip, saturated 0-pace, ARC transition overlap, Q4 2024 clip, N=1 flag, partial-quarter, bar 12-month window, all-saturated capability returns 0 not NaN.
- **Pace UI in `app.js`** — `setModeVisibility(mode)` hides the date dropdown, chart action buttons, filter pills, and chart legend in pace mode; toggles `.pace-mode` on the container so it expands to fit both charts. A second `Chart.js` instance (`paceBarChart`) is built lazily for the bar chart. Existing plugins (`inactivityMarker`, `endpointLabel`) already early-return when not in frontier mode — no pace-specific guards needed.

## Depends on

[#53](https://github.com/jackrich000/ai-race/pull/53) — Pace cohort benchmarks + `chartModes` gating. PR 2 renders correctly with the 13 master-state benchmarks today; once #53 merges and this branch rebases, the full 16-benchmark cohort is available.

## Test plan

- [x] `npm test` — 246 tests pass (234 existing + 12 new `pace-chart` cases).
- [x] Headless smoke test via Playwright:
  - Switch to Pace tab → line chart starts Q4 2024, ends Q2 2026 dashed.
  - Bar chart renders 6 capabilities in canonical order.
  - Visual Reasoning + Computer Use bars are outlined (N=1).
  - Date dropdown, action buttons, filter pills, and chart legend hidden in pace mode.
  - Methodology blurb renders the pace text with cohort + caveats.
  - Switching back to Frontier restores all hidden UI chrome.
- [ ] After merge: trigger pipeline to ingest the 3 new benchmarks from #53. The bar chart then includes Aider Polyglot + MMLU-Pro in Coding/Expert Reasoning means, and Terminal-Bench 2.0 in Coding.
- [ ] Visual check on `ai-race.vercel.app` once deployed: bar chart values match `.scratch-pace-v3.json` raw means for overlapping quarters (within rounding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
