### PR TITLE
Streak alert: distinguish real extraction breakage from untracked-only

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -416,20 +416,36 @@ function checkSourceThresholds(rowsBySource, thresholds) {
 
 /**
  * Streak detection on per-lab pipeline_runs history.
- * Two failure modes:
- *   - "no_articles": all N runs have articles_scraped=0 (scraper broken).
- *   - "no_scores":   all N runs have articles_scraped>0 AND scores_yielded=0
- *                    (extraction prompt or page template drift).
- * Labs with fewer than streakThreshold runs are reported as insufficient
- * history rather than triggering an alert.
+ *
+ * Hard alerts (genuine breakage):
+ *   - "no_articles":   all N runs have articles_scraped=0 (index scanner / scraper broken).
+ *   - "no_extraction": all N runs have articles_scraped>0 AND scores_extracted=0
+ *                      (pages parsed, but the LLM pulled zero scores — extraction
+ *                      prompt or page-template drift).
+ *
+ * Soft signal (informational, NOT breakage):
+ *   - "untracked_only": all N runs have articles_scraped>0, scores_extracted>0,
+ *                       AND scores_yielded=0 (extraction is healthy, but nothing
+ *                       landed on a *tracked* benchmark). Usually means the lab is
+ *                       publishing only off-benchmark posts — or, more usefully, that
+ *                       a tracked benchmark is being missed via a name/alias gap.
+ *
+ * scores_extracted is null on pre-migration (009) rows; the strict ===0 / >0 checks
+ * mean neither new rule fires until streakThreshold real-counter runs accumulate, so
+ * the transition can't resurrect a false alarm.
+ *
+ * Labs with fewer than streakThreshold runs are reported as insufficient history
+ * rather than triggering anything.
  *
  * @param {Object<string, Array>} historyByLab - { lab: rows[] }, rows ordered
- *   newest-first, with shape { articles_scraped, scores_yielded, run_started_at }.
+ *   newest-first, with shape
+ *   { articles_scraped, scores_extracted, scores_yielded, run_started_at }.
  * @param {{streakThreshold?: number}} [options]
- * @returns {{alerts: Array, insufficientHistory: Array}}
+ * @returns {{alerts: Array, info: Array, insufficientHistory: Array}}
  */
 function detectStreakAlerts(historyByLab, { streakThreshold = 4 } = {}) {
   const alerts = [];
+  const info = [];
   const insufficientHistory = [];
 
   for (const [lab, rows] of Object.entries(historyByLab)) {
@@ -442,12 +458,14 @@ function detectStreakAlerts(historyByLab, { streakThreshold = 4 } = {}) {
 
     if (window.every(r => r.articles_scraped === 0)) {
       alerts.push({ lab, kind: "no_articles", since: oldest });
-    } else if (window.every(r => r.articles_scraped > 0 && r.scores_yielded === 0)) {
-      alerts.push({ lab, kind: "no_scores", since: oldest });
+    } else if (window.every(r => r.articles_scraped > 0 && r.scores_extracted === 0)) {
+      alerts.push({ lab, kind: "no_extraction", since: oldest });
+    } else if (window.every(r => r.articles_scraped > 0 && r.scores_extracted > 0 && r.scores_yielded === 0)) {
+      info.push({ lab, kind: "untracked_only", since: oldest });
     }
   }
 
-  return { alerts, insufficientHistory };
+  return { alerts, info, insufficientHistory };
 }
 
 /**

--- a/migrations/009-add-scores-extracted-to-pipeline-runs.sql
+++ b/migrations/009-add-scores-extracted-to-pipeline-runs.sql
@@ -1,0 +1,15 @@
+-- Migration 009: Add scores_extracted to pipeline_runs for sharper streak alerts.
+-- The original streak alert ("no_scores") fired when articles_scraped>0 but
+-- scores_yielded=0 — but scores_yielded only counts tracked-and-ingested scores, so
+-- a lab publishing rich posts full of *untracked* benchmarks (voice, cyber, bio,
+-- agentic) tripped a false "extraction broken" alarm. scores_extracted counts every
+-- score the LLM pulled from a page before triage, which lets detectStreakAlerts tell
+-- a genuine parse failure (extracted=0) apart from "healthy extraction, nothing on a
+-- tracked benchmark" (extracted>0, yielded=0).
+--
+-- Deliberately NULLable with no default: existing rows stay NULL ("unknown"), so the
+-- new no_extraction / untracked_only rules can't fire on pre-migration history and
+-- won't resurrect the old false alarm during the ~4-run bootstrap.
+-- Applied via scripts/apply-migrations.mjs (npm run migrate).
+
+ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS scores_extracted INTEGER;

--- a/scripts/extract-model-cards.mjs
+++ b/scripts/extract-model-cards.mjs
@@ -1284,6 +1284,14 @@ async function main() {
 
       rawRows.push(row);
 
+      // Every extracted score counts toward scoresExtracted — INCLUDING untracked
+      // benchmarks (which never reach articleRows below). This is the whole point:
+      // it separates "extraction broke" (0 extracted) from "lab only posted
+      // untracked benchmarks" (extracted>0, yielded=0).
+      if (pipelineStats[lab]) {
+        pipelineStats[lab].scoresExtracted++;
+      }
+
       // Per-score triage (tracked benchmarks only)
       if (normalized.key && BENCHMARK_META[normalized.key]) {
         const bestKey = `${normalized.key}|${lab}`;
@@ -1362,13 +1370,6 @@ async function main() {
     // Collect final triage results and set triage_status on raw rows
     for (const { row, result } of articleRows) {
       const summary = `${row.model} on ${row.benchmark}: ${row.score}${row.model_variant ? ` [${row.model_variant}]` : ""} (${result.action}: ${result.reason})`;
-
-      // Every row here is a score the LLM extracted from a page, regardless of
-      // triage outcome — counts toward scoresExtracted (the "extraction is alive"
-      // signal), separately from scoresYielded (tracked-and-ingested below).
-      if (pipelineStats[row.lab]) {
-        pipelineStats[row.lab].scoresExtracted++;
-      }
 
       // Map triage action to status stored in DB
       const statusMap = { ingest: "ingest", review: "flag", reject: "reject" };

--- a/scripts/extract-model-cards.mjs
+++ b/scripts/extract-model-cards.mjs
@@ -932,11 +932,14 @@ async function main() {
 
   // Per-lab counters for the streak alert in run-pipeline.mjs.
   // articlesScraped: page extraction succeeded (regardless of LLM yield).
-  // scoresYielded:   triage emitted at least one ingestable score.
+  // scoresExtracted: total scores the LLM pulled from articles, before triage.
+  //                  Distinguishes "extraction broke" (0 extracted) from "lab only
+  //                  posted untracked benchmarks" (extracted>0 but yielded=0).
+  // scoresYielded:   triage emitted at least one ingestable (tracked) score.
   const pipelineStats = {};
   for (const source of LAB_SOURCES) {
     if (!pipelineStats[source.lab]) {
-      pipelineStats[source.lab] = { articlesScraped: 0, scoresYielded: 0 };
+      pipelineStats[source.lab] = { articlesScraped: 0, scoresExtracted: 0, scoresYielded: 0 };
     }
   }
 
@@ -1360,6 +1363,13 @@ async function main() {
     for (const { row, result } of articleRows) {
       const summary = `${row.model} on ${row.benchmark}: ${row.score}${row.model_variant ? ` [${row.model_variant}]` : ""} (${result.action}: ${result.reason})`;
 
+      // Every row here is a score the LLM extracted from a page, regardless of
+      // triage outcome — counts toward scoresExtracted (the "extraction is alive"
+      // signal), separately from scoresYielded (tracked-and-ingested below).
+      if (pipelineStats[row.lab]) {
+        pipelineStats[row.lab].scoresExtracted++;
+      }
+
       // Map triage action to status stored in DB
       const statusMap = { ingest: "ingest", review: "flag", reject: "reject" };
       row.triage_status = statusMap[result.action] || null;
@@ -1580,6 +1590,7 @@ async function main() {
       run_started_at: runStartIso,
       lab,
       articles_scraped: s.articlesScraped,
+      scores_extracted: s.scoresExtracted,
       scores_yielded: s.scoresYielded,
     }));
     if (runRows.length > 0) {

--- a/scripts/run-pipeline.mjs
+++ b/scripts/run-pipeline.mjs
@@ -329,7 +329,7 @@ async function queryStreakAlerts(supabase) {
   const queries = EXTRACTED_LABS.map(async (lab) => {
     const { data, error } = await supabase
       .from("pipeline_runs")
-      .select("articles_scraped, scores_yielded, run_started_at")
+      .select("articles_scraped, scores_extracted, scores_yielded, run_started_at")
       .eq("lab", lab)
       .order("run_started_at", { ascending: false })
       .limit(STREAK_THRESHOLD);
@@ -583,6 +583,7 @@ function buildReport({ changes, flagged, rejected, unknownVariants, extractResul
   // ─── Lab Freshness ──────────────────────────────────────
   const staleLabs = labFreshness.filter(l => l.stale);
   const streakAlerts = (streak && streak.alerts) || [];
+  const streakInfo = (streak && streak.info) || [];
   const insufficientHistory = (streak && streak.insufficientHistory) || [];
   // Flatten insufficient-history into a lookup so we can render it inline.
   const insufficientByLab = new Map(insufficientHistory.map(h => [h.lab, h.runsSoFar]));
@@ -606,16 +607,31 @@ function buildReport({ changes, flagged, rejected, unknownVariants, extractResul
     parts.push("");
     parts.push(`## Streak Alerts (${streakAlerts.length})`);
     parts.push("");
-    parts.push("Labs that have shown the same failure pattern for 4 consecutive runs. Usually indicates the index scanner / scraper / extraction prompt has broken silently.");
+    parts.push("Labs that have shown the same failure pattern for 4 consecutive runs. Indicates the index scanner / scraper / extraction prompt has broken silently.");
     parts.push("");
     parts.push("| Lab | Kind | Since |");
     parts.push("|-----|------|-------|");
     for (const a of streakAlerts) {
       const kindLabel = a.kind === "no_articles"
         ? "No articles scraped — index scanner / scraper broken"
-        : "Articles scraped, no scores yielded — extraction prompt or page template drift";
+        : "Articles scraped but zero scores extracted — extraction prompt or page template drift";
       const sinceDate = a.since ? a.since.split("T")[0] : "unknown";
       parts.push(`| ${labName(a.lab)} | ${kindLabel} | ${sinceDate} |`);
+    }
+  }
+
+  // ─── Extraction Notes (soft signal, not a breakage) ─────
+  if (streakInfo.length > 0) {
+    parts.push("");
+    parts.push(`## Extraction Notes (${streakInfo.length})`);
+    parts.push("");
+    parts.push("Labs extracting scores fine for 4 consecutive runs, but none landed on a *tracked* benchmark. Usually the lab is publishing only off-benchmark posts — but if you expect a tracked score here, check for a benchmark name/alias gap.");
+    parts.push("");
+    parts.push("| Lab | Note | Since |");
+    parts.push("|-----|------|-------|");
+    for (const a of streakInfo) {
+      const sinceDate = a.since ? a.since.split("T")[0] : "unknown";
+      parts.push(`| ${labName(a.lab)} | Healthy extraction, 0 tracked-benchmark scores | ${sinceDate} |`);
     }
   }
 
@@ -953,6 +969,9 @@ async function main() {
   }
   if (streak.alerts.length > 0) {
     console.warn(`  Streak alerts: ${streak.alerts.map(a => `${labName(a.lab)} (${a.kind})`).join(", ")}`);
+  }
+  if (streak.info && streak.info.length > 0) {
+    console.log(`  Extraction notes: ${streak.info.map(a => `${labName(a.lab)} (${a.kind})`).join(", ")}`);
   }
   if (streak.insufficientHistory.length > 0) {
     console.log(`  Insufficient history: ${streak.insufficientHistory.map(h => `${labName(h.lab)} (${h.runsSoFar}/4)`).join(", ")}`);

--- a/tests/health-checks.test.js
+++ b/tests/health-checks.test.js
@@ -84,9 +84,11 @@ describe("checkSourceThresholds", () => {
 
 // ─── detectStreakAlerts ──────────────────────────────────────
 
-function row(scraped, yielded, dateStr) {
+// row(articles_scraped, scores_extracted, scores_yielded, run_started_at)
+function row(scraped, extracted, yielded, dateStr) {
   return {
     articles_scraped: scraped,
+    scores_extracted: extracted,
     scores_yielded: yielded,
     run_started_at: dateStr,
   };
@@ -95,10 +97,11 @@ function row(scraped, yielded, dateStr) {
 describe("detectStreakAlerts", () => {
   it("returns insufficient history when fewer than 4 runs exist", () => {
     const history = {
-      openai: [row(5, 10, "2026-05-07"), row(0, 0, "2026-04-30")],
+      openai: [row(5, 8, 10, "2026-05-07"), row(0, 0, 0, "2026-04-30")],
     };
     const result = detectStreakAlerts(history);
     expect(result.alerts).toEqual([]);
+    expect(result.info).toEqual([]);
     expect(result.insufficientHistory).toEqual([{ lab: "openai", runsSoFar: 2 }]);
   });
 
@@ -109,26 +112,27 @@ describe("detectStreakAlerts", () => {
     expect(result.insufficientHistory).toEqual([{ lab: "openai", runsSoFar: 0 }]);
   });
 
-  it("does not alert when one of the 4 runs is non-zero", () => {
+  it("does not alert when one of the 4 runs is healthy", () => {
     const history = {
       anthropic: [
-        row(0, 0, "2026-05-07"),
-        row(0, 0, "2026-04-30"),
-        row(2, 5, "2026-04-23"),  // breaks the streak
-        row(0, 0, "2026-04-16"),
+        row(0, 0, 0, "2026-05-07"),
+        row(0, 0, 0, "2026-04-30"),
+        row(2, 5, 5, "2026-04-23"),  // breaks the streak
+        row(0, 0, 0, "2026-04-16"),
       ],
     };
     const result = detectStreakAlerts(history);
     expect(result.alerts).toEqual([]);
+    expect(result.info).toEqual([]);
   });
 
   it("alerts on no_articles when all 4 runs have articles_scraped=0", () => {
     const history = {
       chinese: [
-        row(0, 0, "2026-05-07"),
-        row(0, 0, "2026-04-30"),
-        row(0, 0, "2026-04-23"),
-        row(0, 0, "2026-04-16"),
+        row(0, 0, 0, "2026-05-07"),
+        row(0, 0, 0, "2026-04-30"),
+        row(0, 0, 0, "2026-04-23"),
+        row(0, 0, 0, "2026-04-16"),
       ],
     };
     const result = detectStreakAlerts(history);
@@ -137,29 +141,73 @@ describe("detectStreakAlerts", () => {
     ]);
   });
 
-  it("alerts on no_scores when articles_scraped > 0 but scores_yielded = 0 for 4 runs", () => {
+  it("alerts on no_extraction when articles scraped but ZERO scores extracted for 4 runs", () => {
     const history = {
       google: [
-        row(3, 0, "2026-05-07"),
-        row(2, 0, "2026-04-30"),
-        row(1, 0, "2026-04-23"),
-        row(2, 0, "2026-04-16"),
+        row(3, 0, 0, "2026-05-07"),
+        row(2, 0, 0, "2026-04-30"),
+        row(1, 0, 0, "2026-04-23"),
+        row(2, 0, 0, "2026-04-16"),
       ],
     };
     const result = detectStreakAlerts(history);
     expect(result.alerts).toEqual([
-      { lab: "google", kind: "no_scores", since: "2026-04-16" },
+      { lab: "google", kind: "no_extraction", since: "2026-04-16" },
     ]);
+    expect(result.info).toEqual([]);
+  });
+
+  it("emits an untracked_only INFO (not an alert) when extraction is healthy but nothing is tracked", () => {
+    // The exact false-positive that fired for weeks: pages parse, the LLM pulls
+    // plenty of scores, but they're all on untracked benchmarks → yielded=0.
+    const history = {
+      openai: [
+        row(3, 12, 0, "2026-05-07"),
+        row(2, 5, 0, "2026-04-30"),
+        row(1, 3, 0, "2026-04-23"),
+        row(2, 7, 0, "2026-04-16"),
+      ],
+    };
+    const result = detectStreakAlerts(history);
+    expect(result.alerts).toEqual([]);
+    expect(result.info).toEqual([
+      { lab: "openai", kind: "untracked_only", since: "2026-04-16" },
+    ]);
+  });
+
+  it("does not flag a fully healthy lab (extracted>0 and yielded>0)", () => {
+    const history = {
+      anthropic: [
+        row(3, 12, 4, "d4"), row(2, 5, 2, "d3"), row(1, 3, 1, "d2"), row(2, 7, 3, "d1"),
+      ],
+    };
+    const result = detectStreakAlerts(history);
+    expect(result.alerts).toEqual([]);
+    expect(result.info).toEqual([]);
+  });
+
+  it("does not fire new rules on pre-migration rows where scores_extracted is null", () => {
+    // Legacy rows (articles>0, scores_yielded=0, scores_extracted=null) must NOT
+    // resurrect the old false alarm: ===0 / >0 are both false against null.
+    const legacy = (scraped, yielded, dateStr) => ({
+      articles_scraped: scraped, scores_extracted: null, scores_yielded: yielded, run_started_at: dateStr,
+    });
+    const history = {
+      google: [legacy(3, 0, "d4"), legacy(2, 0, "d3"), legacy(1, 0, "d2"), legacy(2, 0, "d1")],
+    };
+    const result = detectStreakAlerts(history);
+    expect(result.alerts).toEqual([]);
+    expect(result.info).toEqual([]);
   });
 
   it("uses only the most recent 4 runs when more history exists", () => {
     const history = {
       openai: [
-        row(0, 0, "2026-05-07"),
-        row(0, 0, "2026-04-30"),
-        row(0, 0, "2026-04-23"),
-        row(0, 0, "2026-04-16"),
-        row(5, 10, "2026-04-09"), // older non-zero — should be ignored
+        row(0, 0, 0, "2026-05-07"),
+        row(0, 0, 0, "2026-04-30"),
+        row(0, 0, 0, "2026-04-23"),
+        row(0, 0, 0, "2026-04-16"),
+        row(5, 8, 10, "2026-04-09"), // older healthy run — should be ignored
       ],
     };
     const result = detectStreakAlerts(history);
@@ -168,38 +216,41 @@ describe("detectStreakAlerts", () => {
     ]);
   });
 
-  it("does not alert no_scores if any window run has articles=0 (that's no_articles territory)", () => {
-    // Mixed: 3 runs with articles>0/scores=0, 1 run with articles=0/scores=0.
+  it("does not alert no_extraction if any window run has articles=0 (that's no_articles territory)", () => {
+    // Mixed: 3 runs with articles>0/extracted=0, 1 run with articles=0.
     // Neither pure pattern matches.
     const history = {
       xai: [
-        row(2, 0, "2026-05-07"),
-        row(1, 0, "2026-04-30"),
-        row(0, 0, "2026-04-23"),  // breaks no_scores (articles=0)
-        row(2, 0, "2026-04-16"),
+        row(2, 0, 0, "2026-05-07"),
+        row(1, 0, 0, "2026-04-30"),
+        row(0, 0, 0, "2026-04-23"),  // breaks no_extraction (articles=0)
+        row(2, 0, 0, "2026-04-16"),
       ],
     };
     const result = detectStreakAlerts(history);
     expect(result.alerts).toEqual([]);
+    expect(result.info).toEqual([]);
   });
 
-  it("alerts independently per lab", () => {
+  it("classifies independently per lab", () => {
     const history = {
-      openai: [row(0, 0, "d4"), row(0, 0, "d3"), row(0, 0, "d2"), row(0, 0, "d1")],
-      anthropic: [row(5, 10, "d4"), row(5, 10, "d3"), row(5, 10, "d2"), row(5, 10, "d1")],
-      google: [row(2, 0, "d4"), row(2, 0, "d3"), row(2, 0, "d2"), row(2, 0, "d1")],
+      openai: [row(0, 0, 0, "d4"), row(0, 0, 0, "d3"), row(0, 0, 0, "d2"), row(0, 0, 0, "d1")],
+      anthropic: [row(5, 9, 10, "d4"), row(5, 9, 10, "d3"), row(5, 9, 10, "d2"), row(5, 9, 10, "d1")],
+      google: [row(2, 0, 0, "d4"), row(2, 0, 0, "d3"), row(2, 0, 0, "d2"), row(2, 0, 0, "d1")],
+      xai: [row(2, 4, 0, "d4"), row(2, 4, 0, "d3"), row(2, 4, 0, "d2"), row(2, 4, 0, "d1")],
     };
     const result = detectStreakAlerts(history);
     expect(result.alerts).toHaveLength(2);
     expect(result.alerts.find(a => a.lab === "openai").kind).toBe("no_articles");
-    expect(result.alerts.find(a => a.lab === "google").kind).toBe("no_scores");
-    // anthropic is healthy → no alert, no insufficient history
+    expect(result.alerts.find(a => a.lab === "google").kind).toBe("no_extraction");
+    expect(result.info).toEqual([{ lab: "xai", kind: "untracked_only", since: "d1" }]);
+    // anthropic is healthy → no alert, no info, no insufficient history
     expect(result.insufficientHistory).toEqual([]);
   });
 
   it("custom streakThreshold of 2 fires after 2 zero runs", () => {
     const history = {
-      openai: [row(0, 0, "d2"), row(0, 0, "d1")],
+      openai: [row(0, 0, 0, "d2"), row(0, 0, 0, "d1")],
     };
     const result = detectStreakAlerts(history, { streakThreshold: 2 });
     expect(result.alerts).toEqual([


### PR DESCRIPTION
## Problem
The pipeline's `no_scores` streak alert fired on **OpenAI, Google DeepMind, and xAI for ~6 weeks** as a false positive (issues #60–#63). Root cause: `scores_yielded` counts only **tracked-and-ingested** scores, so a lab that publishes posts full of *untracked* benchmarks (voice, cyber, bio, agentic — increasingly common) trips an "extraction broken" alarm even though the LLM extracted dozens of rows perfectly. That's alert fatigue on the very health-check system PR #48 added.

Investigation this session confirmed the scraper is healthy across all three labs; they simply published off-(tracked)-benchmark content (xAI also genuinely quiet). Verified against `benchmark_raw` + each lab's recent releases.

## Fix
Add `scores_extracted` — every score the LLM pulls from a page **before** triage — so `detectStreakAlerts` can split the ambiguous case:

| Kind | Condition | Severity |
|------|-----------|----------|
| `no_articles` | articles=0 | hard alert (unchanged) |
| `no_extraction` | articles>0, **extracted=0** | hard alert — genuine prompt/template drift |
| `untracked_only` | articles>0, extracted>0, **yielded=0** | **soft info**, not an alarm |

The soft `untracked_only` signal doubles as an early warning for benchmark name/alias gaps — exactly what silently stranded the Gemini 3.5 OSWorld and GPT-5.5 MMMU-Pro scores before they were caught by hand.

## Migration safety
`migration 009` adds the column **NULLable with no default**, so pre-migration rows stay `NULL` and the new `===0`/`>0` rules can't fire during the ~4-run bootstrap (no resurrected false alarm). Already applied to the DB; recorded hash pinned to the CRLF bytes per repo convention.

## Changes
- `migrations/009-*.sql` — add `pipeline_runs.scores_extracted`
- `scripts/extract-model-cards.mjs` — count + persist `scores_extracted`
- `lib/pipeline.js` — `detectStreakAlerts` returns `{alerts, info, insufficientHistory}`
- `scripts/run-pipeline.mjs` — relabel hard alert, render new "Extraction Notes" section
- `tests/health-checks.test.js` — rewritten streak tests incl. legacy-null backward-compat

Tests: 1130 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)